### PR TITLE
Introduce runner and override makeConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,3 +238,6 @@ temp-test-unit-cover.txt
 
 # server dev env for Air
 .air.toml
+
+# e2e framework
+monitoring/

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	cosmossdk.io/log v1.6.0
 	cosmossdk.io/math v1.5.3
 	cosmossdk.io/store v1.10.0-rc.1.0.20241218084712-ca559989da43
+	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c
 	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/cometbft/cometbft v1.0.1-0.20241220100824-07c737de00ff
 	github.com/cometbft/cometbft/api v1.0.1-0.20241220100824-07c737de00ff
@@ -29,6 +30,7 @@ require (
 	github.com/go-faster/xor v1.0.0
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-metrics v0.5.4
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/holiman/uint256 v1.3.2
@@ -153,7 +155,6 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect

--- a/scripts/build/build.mk
+++ b/scripts/build/build.mk
@@ -127,11 +127,11 @@ build-docker-cmt-e2e: ## build a docker image containing `beacond` used in the e
 	-t cometbft/e2e-node:local-version \
 	./testing # work around .dockerignore restrictions in the root folder
 
-build-runner: ## build e2e runner
+build-cmt-e2e-runner: ## build e2e runner
 		@echo "Build the e2e runner..."
 		@go build -mod=readonly -o $(OUT_DIR)/runner ./testing/runner
 
-build-e2e:
+build-cmt-e2e:
 	@$(MAKE) build-docker VERSION=local-version \
 		build-docker-e2e \
 		build-runner

--- a/scripts/build/build.mk
+++ b/scripts/build/build.mk
@@ -126,3 +126,12 @@ build-docker-e2e: ## build a docker image containing `beacond` used in the e2e t
 	-f ${DOCKERFILE_E2E} \
 	-t cometbft/e2e-node:local-version \
 	./testing # work around .dockerignore restrictions in the root folder
+
+build-runner: ## build e2e runner
+		@echo "Build the e2e runner..."
+		@go build -mod=readonly -o $(OUT_DIR)/runner ./testing/runner
+
+build-e2e:
+	@$(MAKE) build-docker VERSION=local-version \
+		build-docker-e2e \
+		build-runner

--- a/scripts/build/testing.mk
+++ b/scripts/build/testing.mk
@@ -407,3 +407,14 @@ test-e2e-deposits: ## run e2e tests
 
 test-e2e-deposits-no-build:
 	go test -timeout 0 -tags e2e,bls12381,test ./testing/e2e/. -v -testify.m TestDepositRobustness
+
+###############################################################################
+###                          E2E Framework Testing                          ###
+###############################################################################
+
+test-e2e-single: ## run e2e single node test
+	@$(MAKE) build-e2e test-e2e-single-no-build
+
+test-e2e-single-no-build:
+	mkdir -p monitoring
+	testing/files/run-multiple.sh testing/networks/single.toml

--- a/scripts/build/testing.mk
+++ b/scripts/build/testing.mk
@@ -412,9 +412,8 @@ test-e2e-deposits-no-build:
 ###                       CometBFT  E2E Framework Testing                          ###
 ###############################################################################
 
-test-e2e-single: ## run e2e single node test
-	@$(MAKE) build-e2e test-e2e-single-no-build
+test-cmt-e2e-single-run: ## run e2e single node test
+	@$(MAKE) build-cmt-e2e test-e2e-single-no-build
 
-test-e2e-single-no-build:
-	mkdir -p monitoring
+test-cmt-e2e-single-no-build:
 	testing/files/run-multiple.sh testing/networks/single.toml

--- a/scripts/build/testing.mk
+++ b/scripts/build/testing.mk
@@ -409,7 +409,7 @@ test-e2e-deposits-no-build:
 	go test -timeout 0 -tags e2e,bls12381,test ./testing/e2e/. -v -testify.m TestDepositRobustness
 
 ###############################################################################
-###                          E2E Framework Testing                          ###
+###                       CometBFT  E2E Framework Testing                          ###
 ###############################################################################
 
 test-e2e-single: ## run e2e single node test

--- a/testing/files/run-multiple.sh
+++ b/testing/files/run-multiple.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# This is a convenience script that takes a list of testnet manifests
+# as arguments and runs each one of them sequentially. If a testnet
+# fails, the container logs are dumped to stdout along with the testnet
+# manifest, but the remaining testnets are still run.
+#
+# This is mostly used to run generated networks in nightly CI jobs.
+#
+
+set -euo pipefail
+
+if [[ $# == 0 ]]; then
+	echo "Usage: $0 [MANIFEST...]" >&2
+	exit 1
+fi
+
+FAILED=()
+RUNNER="${RUNNER:-build/bin/runner}"
+
+for MANIFEST in "$@"; do
+	START=$SECONDS
+	echo "==> Running testnet: $MANIFEST"
+	echo "==> Manifest:"
+	cat "$MANIFEST"
+
+	if ! "$RUNNER" -f "$MANIFEST"; then
+		echo "==> Testnet failed"
+
+		echo "==> Dumping container logs for $MANIFEST..."
+		"$RUNNER" -f "$MANIFEST" logs
+
+		echo "==> Cleaning up failed testnet $MANIFEST..."
+		"$RUNNER" -f "$MANIFEST" cleanup
+
+		FAILED+=("$MANIFEST")
+	fi
+
+	echo "==> Completed testnet $MANIFEST in $(( SECONDS - START ))s"
+	echo ""
+done
+
+if [[ ${#FAILED[@]} -ne 0 ]]; then
+	echo "${#FAILED[@]} testnets failed:"
+	for MANIFEST in "${FAILED[@]}"; do
+		echo "- $MANIFEST"
+	done
+	exit 1
+else
+	echo "All testnets successful"
+fi

--- a/testing/networks/single.toml
+++ b/testing/networks/single.toml
@@ -1,0 +1,1 @@
+[node.validator]

--- a/testing/runner/benchmark.go
+++ b/testing/runner/benchmark.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"path/filepath"
+	"time"
+
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/types"
+)
+
+// Benchmark is a simple function for fetching, calculating and printing
+// the following metrics:
+// 1. Average block production time
+// 2. Block interval standard deviation
+// 3. Max block interval (slowest block)
+// 4. Min block interval (fastest block)
+//
+// Metrics are based of the `benchmarkLength`, the amount of consecutive blocks
+// sampled from in the testnet.
+func Benchmark(ctx context.Context, testnet *e2e.Testnet, benchmarkLength int64) error {
+	block, _, err := waitForHeight(ctx, testnet, 0)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Beginning benchmark period...", "height", block.Height)
+	startAt := time.Now()
+
+	// wait for the length of the benchmark period in blocks to pass. We allow 5 seconds for each block
+	// which should be sufficient.
+	waitingTime := time.Duration(benchmarkLength*5) * time.Second
+	endHeight, err := waitForAllNodes(ctx, testnet, block.Height+benchmarkLength, waitingTime)
+	if err != nil {
+		return err
+	}
+	dur := time.Since(startAt)
+
+	logger.Info("Ending benchmark period", "height", endHeight)
+
+	// fetch a sample of blocks
+	blocks, err := fetchBlockChainSample(ctx, testnet, benchmarkLength)
+	if err != nil {
+		return err
+	}
+
+	// slice into time intervals and collate data
+	timeIntervals := splitIntoBlockIntervals(blocks)
+	testnetStats := extractTestnetStats(timeIntervals)
+	testnetStats.populateTxns(blocks)
+	testnetStats.totalTime = dur
+	testnetStats.startHeight = blocks[0].Header.Height
+	testnetStats.endHeight = blocks[len(blocks)-1].Header.Height
+
+	// print and return
+	logger.Info(testnetStats.OutputJSON(testnet))
+	return nil
+}
+
+func (t *testnetStats) populateTxns(blocks []*types.BlockMeta) {
+	t.numtxns = 0
+	for _, b := range blocks {
+		t.numtxns += int64(b.NumTxs)
+	}
+}
+
+type testnetStats struct {
+	startHeight int64
+	endHeight   int64
+
+	numtxns   int64
+	totalTime time.Duration
+	// average time to produce a block
+	mean time.Duration
+	// standard deviation of block production
+	std float64
+	// longest time to produce a block
+	max time.Duration
+	// shortest time to produce a block
+	min time.Duration
+}
+
+func (t *testnetStats) OutputJSON(net *e2e.Testnet) string {
+	jsn, err := json.Marshal(map[string]any{
+		"case":         filepath.Base(net.File),
+		"start_height": t.startHeight,
+		"end_height":   t.endHeight,
+		"blocks":       t.endHeight - t.startHeight,
+		"stddev":       t.std,
+		"mean":         t.mean.Seconds(),
+		"max":          t.max.Seconds(),
+		"min":          t.min.Seconds(),
+		"size":         len(net.Nodes),
+		"txns":         t.numtxns,
+		"dur":          t.totalTime.Seconds(),
+	})
+	if err != nil {
+		return ""
+	}
+
+	return string(jsn)
+}
+
+func (t *testnetStats) String() string {
+	return fmt.Sprintf(`Benchmarked from height %v to %v
+	Mean Block Interval: %v
+	Standard Deviation: %f
+	Max Block Interval: %v
+	Min Block Interval: %v
+	`,
+		t.startHeight,
+		t.endHeight,
+		t.mean,
+		t.std,
+		t.max,
+		t.min,
+	)
+}
+
+// fetchBlockChainSample waits for `benchmarkLength` amount of blocks to pass, fetching
+// all of the headers for these blocks from an archive node and returning it.
+func fetchBlockChainSample(ctx context.Context, testnet *e2e.Testnet, benchmarkLength int64) ([]*types.BlockMeta, error) {
+	var blocks []*types.BlockMeta
+
+	// Find the first archive node
+	archiveNode := testnet.ArchiveNodes()[0]
+	c, err := archiveNode.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	// find the latest height
+	s, err := c.Status(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	to := s.SyncInfo.LatestBlockHeight
+	from := to - benchmarkLength + 1
+	if from <= testnet.InitialHeight {
+		return nil, fmt.Errorf("tesnet was unable to reach required height for benchmarking (latest height %d)", to)
+	}
+
+	// Fetch blocks
+	for from < to {
+		// fetch the blockchain metas. Currently we can only fetch 20 at a time
+		resp, err := c.BlockchainInfo(ctx, from, min(from+19, to))
+		if err != nil {
+			return nil, err
+		}
+
+		blockMetas := resp.BlockMetas
+		// we receive blocks in descending order so we have to add them in reverse
+		for i := len(blockMetas) - 1; i >= 0; i-- {
+			if blockMetas[i].Header.Height != from {
+				return nil, fmt.Errorf("node gave us another header. Wanted %d, got %d",
+					from,
+					blockMetas[i].Header.Height,
+				)
+			}
+			from++
+			blocks = append(blocks, blockMetas[i])
+		}
+	}
+
+	return blocks, nil
+}
+
+func splitIntoBlockIntervals(blocks []*types.BlockMeta) []time.Duration {
+	intervals := make([]time.Duration, len(blocks)-1)
+	lastTime := blocks[0].Header.Time
+	for i, block := range blocks {
+		// skip the first block
+		if i == 0 {
+			continue
+		}
+
+		intervals[i-1] = block.Header.Time.Sub(lastTime)
+		lastTime = block.Header.Time
+	}
+	return intervals
+}
+
+func extractTestnetStats(intervals []time.Duration) testnetStats {
+	var (
+		sum, mean time.Duration
+		std       float64
+		max       = intervals[0]
+		min       = intervals[0]
+	)
+
+	for _, interval := range intervals {
+		sum += interval
+
+		if interval > max {
+			max = interval
+		}
+
+		if interval < min {
+			min = interval
+		}
+	}
+	mean = sum / time.Duration(len(intervals))
+
+	for _, interval := range intervals {
+		diff := (interval - mean).Seconds()
+		std += math.Pow(diff, 2)
+	}
+	std = math.Sqrt(std / float64(len(intervals)))
+
+	return testnetStats{
+		mean: mean,
+		std:  std,
+		max:  max,
+		min:  min,
+	}
+}
+
+func min(a, b int64) int64 {
+	if a > b {
+		return b
+	}
+	return a
+}

--- a/testing/runner/cleanup.go
+++ b/testing/runner/cleanup.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/test/e2e/pkg/exec"
+	"github.com/cometbft/cometbft/test/e2e/pkg/infra/docker"
+)
+
+// Cleanup removes the Docker Compose containers and testnet directory.
+func Cleanup(testnet *e2e.Testnet) error {
+	err := cleanupDocker()
+	if err != nil {
+		return err
+	}
+	err = cleanupDir(testnet.Dir)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// cleanupDocker removes all E2E resources (with label e2e=True), regardless
+// of testnet.
+func cleanupDocker() error {
+	logger.Info("Removing Docker containers and networks")
+
+	// GNU xargs requires the -r flag to not run when input is empty, macOS
+	// does this by default. Ugly, but works.
+	xargsR := `$(if [[ $OSTYPE == "linux-gnu"* ]]; then echo -n "-r"; fi)`
+
+	err := exec.Command(context.Background(), "bash", "-c", fmt.Sprintf(
+		"docker container ls -qa --filter label=e2e | xargs %v docker container rm -f", xargsR))
+	if err != nil {
+		return err
+	}
+
+	err = exec.Command(context.Background(), "bash", "-c", fmt.Sprintf(
+		"docker network ls -q --filter label=e2e | xargs %v docker network rm", xargsR))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// cleanupDir cleans up a testnet directory.
+func cleanupDir(dir string) error {
+	if dir == "" {
+		return errors.New("no directory set")
+	}
+
+	_, err := os.Stat(dir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	logger.Info("Clean up testnet directory", "dir", dir)
+
+	// On Linux, some local files in the volume will be owned by root since CometBFT
+	// runs as root inside the container, so we need to clean them up from within a
+	// container running as root too.
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return err
+	}
+	err = docker.Exec(context.Background(), "run", "--rm", "--entrypoint", "", "-v", fmt.Sprintf("%v:/network", absDir),
+		"cometbft/e2e-node:local-version", "sh", "-c", "rm -rf /network/*/")
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(dir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/testing/runner/evidence.go
+++ b/testing/runner/evidence.go
@@ -1,0 +1,393 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+
+	cmtversion "github.com/cometbft/cometbft/api/cometbft/version/v1"
+	"github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/crypto/tmhash"
+	cmtjson "github.com/cometbft/cometbft/libs/json"
+	"github.com/cometbft/cometbft/privval"
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/types"
+	"github.com/cometbft/cometbft/version"
+)
+
+// 1 in 4 evidence is light client evidence, the rest is duplicate vote evidence.
+const lightClientEvidenceRatio = 4
+
+// InjectEvidence takes a running testnet and generates an amount of valid/invalid
+// evidence and broadcasts it to a random node through the rpc endpoint `/broadcast_evidence`.
+// Evidence is random and can be a mixture of LightClientAttackEvidence and
+// DuplicateVoteEvidence.
+func InjectEvidence(ctx context.Context, r *rand.Rand, testnet *e2e.Testnet, amount int) error {
+	// select a random node
+	var targetNode *e2e.Node
+
+	for _, idx := range r.Perm(len(testnet.Nodes)) {
+		targetNode = testnet.Nodes[idx]
+
+		if targetNode.Mode == e2e.ModeSeed || targetNode.Mode == e2e.ModeLight {
+			targetNode = nil
+			continue
+		}
+
+		break
+	}
+
+	if targetNode == nil {
+		return errors.New("could not find node to inject evidence into")
+	}
+
+	logger.Info(fmt.Sprintf("Injecting evidence through %v (amount: %d)...", targetNode.Name, amount))
+
+	client, err := targetNode.Client()
+	if err != nil {
+		return err
+	}
+
+	// request the latest block and validator set from the node
+	blockRes, err := client.Block(ctx, nil)
+	if err != nil {
+		return err
+	}
+	evidenceHeight := blockRes.Block.Height
+	waitHeight := blockRes.Block.Height + 3
+
+	nValidators := 100
+	valRes, err := client.Validators(ctx, &evidenceHeight, nil, &nValidators)
+	if err != nil {
+		return err
+	}
+
+	valSet, err := types.ValidatorSetFromExistingValidators(valRes.Validators)
+	if err != nil {
+		return err
+	}
+
+	// get the private keys of all the validators in the network
+	privVals, err := getPrivateValidatorKeys(testnet)
+	if err != nil {
+		return err
+	}
+
+	// wait for the node to reach the height above the forged height so that
+	// it is able to validate the evidence
+	_, err = waitForNode(ctx, targetNode, waitHeight, time.Minute)
+	if err != nil {
+		return err
+	}
+
+	var ev types.Evidence
+	for i := 0; i < amount; i++ {
+		validEv := true
+		if i%lightClientEvidenceRatio == 0 {
+			validEv = i%(lightClientEvidenceRatio*2) != 0 // Alternate valid and invalid evidence
+			ev, err = generateLightClientAttackEvidence(
+				ctx, privVals, evidenceHeight, valSet, testnet.Name, blockRes.Block.Time, validEv,
+			)
+		} else {
+			var dve *types.DuplicateVoteEvidence
+			dve, err = generateDuplicateVoteEvidence(
+				privVals, evidenceHeight, valSet, testnet.Name, blockRes.Block.Time,
+			)
+			if dve.VoteA.Height < testnet.VoteExtensionsEnableHeight {
+				dve.VoteA.Extension = nil
+				dve.VoteA.ExtensionSignature = nil
+				dve.VoteB.Extension = nil
+				dve.VoteB.ExtensionSignature = nil
+			}
+			ev = dve
+		}
+		if err != nil {
+			return err
+		}
+
+		_, err := client.BroadcastEvidence(ctx, ev)
+		if !validEv {
+			// The tests will count committed evidences later on,
+			// and only valid evidences will make it
+			amount++
+		}
+		if validEv != (err == nil) {
+			if err == nil {
+				return errors.New("submitting invalid evidence didn't return an error")
+			}
+			return err
+		}
+		time.Sleep(5 * time.Second / time.Duration(amount))
+	}
+
+	// wait for the node to reach the height above the forged height so that
+	// it is able to validate the evidence
+	_, err = waitForNode(ctx, targetNode, blockRes.Block.Height+2, 30*time.Second)
+	if err != nil {
+		return err
+	}
+
+	logger.Info(fmt.Sprintf("Finished sending evidence (height %d)", blockRes.Block.Height+2))
+
+	return nil
+}
+
+func getPrivateValidatorKeys(testnet *e2e.Testnet) ([]types.MockPV, error) {
+	privVals := []types.MockPV{}
+
+	for _, node := range testnet.Nodes {
+		if node.Mode == e2e.ModeValidator {
+			privKeyPath := filepath.Join(testnet.Dir, node.Name, PrivvalKeyFile)
+			privKey, err := readPrivKey(privKeyPath)
+			if err != nil {
+				return nil, err
+			}
+			// Create mock private validators from the validators private key. MockPV is
+			// stateless which means we can double vote and do other funky stuff
+			privVals = append(privVals, types.NewMockPVWithParams(privKey, false, false))
+		}
+	}
+
+	return privVals, nil
+}
+
+// MakeCommitFromVoteSet copied from CometBFT's internal/test package.
+func MakeCommitFromVoteSet(blockID types.BlockID, voteSet *types.VoteSet, validators []types.PrivValidator, _ time.Time) (*types.Commit, error) {
+	// all sign
+	for i := 0; i < len(validators); i++ {
+		pubKey, err := validators[i].GetPubKey()
+		if err != nil {
+			return nil, err
+		}
+		vote := &types.Vote{
+			ValidatorAddress: pubKey.Address(),
+			ValidatorIndex:   int32(i),
+			Height:           voteSet.GetHeight(),
+			Round:            voteSet.GetRound(),
+			Type:             types.PrecommitType,
+			BlockID:          blockID,
+		}
+
+		v := vote.ToProto()
+
+		if err := validators[i].SignVote(voteSet.ChainID(), v, false); err != nil {
+			return nil, err
+		}
+		vote.Signature = v.Signature
+		if _, err := voteSet.AddVote(vote); err != nil {
+			return nil, err
+		}
+	}
+
+	return voteSet.MakeExtendedCommit(types.DefaultFeatureParams()).ToCommit(), nil
+}
+
+// creates evidence of a lunatic attack. The height provided is the common height.
+// The forged height happens 2 blocks later.
+func generateLightClientAttackEvidence(
+	ctx context.Context,
+	privVals []types.MockPV,
+	height int64,
+	vals *types.ValidatorSet,
+	chainID string,
+	evTime time.Time,
+	validEvidence bool,
+) (*types.LightClientAttackEvidence, error) {
+	// forge a random header
+	forgedHeight := height + 2
+	forgedTime := evTime.Add(1 * time.Second)
+	header := makeHeaderRandom(chainID, forgedHeight)
+	header.Time = forgedTime
+
+	// add a new bogus validator and remove an existing one to
+	// vary the validator set slightly
+	pv, conflictingVals, err := mutateValidatorSet(ctx, privVals, vals, !validEvidence)
+	if err != nil {
+		return nil, err
+	}
+
+	header.ValidatorsHash = conflictingVals.Hash()
+
+	// create a commit for the forged header
+	blockID := makeBlockID(header.Hash(), 1000, []byte("partshash"))
+	voteSet := types.NewVoteSet(chainID, forgedHeight, 0, types.SignedMsgType(2), conflictingVals)
+	commit, err := MakeCommitFromVoteSet(blockID, voteSet, pv, forgedTime)
+	if err != nil {
+		return nil, err
+	}
+
+	// malleate the last signature of the commit by adding one to its first byte
+	if !validEvidence {
+		commit.Signatures[len(commit.Signatures)-1].Signature[0]++
+	}
+
+	ev := &types.LightClientAttackEvidence{
+		ConflictingBlock: &types.LightBlock{
+			SignedHeader: &types.SignedHeader{
+				Header: header,
+				Commit: commit,
+			},
+			ValidatorSet: conflictingVals,
+		},
+		CommonHeight:     height,
+		TotalVotingPower: vals.TotalVotingPower(),
+		Timestamp:        evTime,
+	}
+	ev.ByzantineValidators = ev.GetByzantineValidators(vals, &types.SignedHeader{
+		Header: makeHeaderRandom(chainID, forgedHeight),
+	})
+	return ev, nil
+}
+
+// generateDuplicateVoteEvidence picks a random validator from the val set and
+// returns duplicate vote evidence against the validator.
+func generateDuplicateVoteEvidence(
+	privVals []types.MockPV,
+	height int64,
+	vals *types.ValidatorSet,
+	chainID string,
+	time time.Time,
+) (*types.DuplicateVoteEvidence, error) {
+	privVal, valIdx, err := getRandomValidatorIndex(privVals, vals)
+	if err != nil {
+		return nil, err
+	}
+	voteA, err := types.MakeVote(privVal, chainID, valIdx, height, 0, 2, makeRandomBlockID(), time)
+	if err != nil {
+		return nil, err
+	}
+	voteB, err := types.MakeVote(privVal, chainID, valIdx, height, 0, 2, makeRandomBlockID(), time)
+	if err != nil {
+		return nil, err
+	}
+	ev, err := types.NewDuplicateVoteEvidence(voteA, voteB, time, vals)
+	if err != nil {
+		return nil, fmt.Errorf("could not generate evidence: %w", err)
+	}
+
+	return ev, nil
+}
+
+// getRandomValidatorIndex picks a random validator from a slice of mock PrivVals that's
+// also part of the validator set, returning the PrivVal and its index in the validator set.
+func getRandomValidatorIndex(privVals []types.MockPV, vals *types.ValidatorSet) (types.MockPV, int32, error) {
+	for _, idx := range rand.Perm(len(privVals)) {
+		pv := privVals[idx]
+		valIdx, _ := vals.GetByAddress(pv.PrivKey.PubKey().Address())
+		if valIdx >= 0 {
+			return pv, valIdx, nil
+		}
+	}
+	return types.MockPV{}, -1, errors.New("no private validator found in validator set")
+}
+
+func readPrivKey(keyFilePath string) (crypto.PrivKey, error) {
+	keyJSONBytes, err := os.ReadFile(keyFilePath)
+	if err != nil {
+		return nil, err
+	}
+	pvKey := privval.FilePVKey{}
+	err = cmtjson.Unmarshal(keyJSONBytes, &pvKey)
+	if err != nil {
+		return nil, fmt.Errorf("error reading PrivValidator key from %v: %w", keyFilePath, err)
+	}
+
+	return pvKey.PrivKey, nil
+}
+
+func makeHeaderRandom(chainID string, height int64) *types.Header {
+	return &types.Header{
+		Version:            cmtversion.Consensus{Block: version.BlockProtocol, App: 1},
+		ChainID:            chainID,
+		Height:             height,
+		Time:               time.Now(),
+		LastBlockID:        makeBlockID([]byte("headerhash"), 1000, []byte("partshash")),
+		LastCommitHash:     crypto.CRandBytes(tmhash.Size),
+		DataHash:           crypto.CRandBytes(tmhash.Size),
+		ValidatorsHash:     crypto.CRandBytes(tmhash.Size),
+		NextValidatorsHash: crypto.CRandBytes(tmhash.Size),
+		ConsensusHash:      crypto.CRandBytes(tmhash.Size),
+		AppHash:            crypto.CRandBytes(tmhash.Size),
+		LastResultsHash:    crypto.CRandBytes(tmhash.Size),
+		EvidenceHash:       crypto.CRandBytes(tmhash.Size),
+		ProposerAddress:    crypto.CRandBytes(crypto.AddressSize),
+	}
+}
+
+func makeRandomBlockID() types.BlockID {
+	return makeBlockID(crypto.CRandBytes(tmhash.Size), 100, crypto.CRandBytes(tmhash.Size))
+}
+
+func makeBlockID(hash []byte, partSetSize uint32, partSetHash []byte) types.BlockID {
+	var (
+		h   = make([]byte, tmhash.Size)
+		psH = make([]byte, tmhash.Size)
+	)
+	copy(h, hash)
+	copy(psH, partSetHash)
+	return types.BlockID{
+		Hash: h,
+		PartSetHeader: types.PartSetHeader{
+			Total: partSetSize,
+			Hash:  psH,
+		},
+	}
+}
+
+// Validator copied from CometBFT's internal/test package.
+func Validator(_ context.Context, votingPower int64) (*types.Validator, types.PrivValidator, error) {
+	privVal := types.NewMockPV()
+	pubKey, err := privVal.GetPubKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	val := types.NewValidator(pubKey, votingPower)
+	return val, privVal, nil
+}
+
+func mutateValidatorSet(
+	ctx context.Context,
+	privVals []types.MockPV,
+	vals *types.ValidatorSet,
+	nop bool,
+) ([]types.PrivValidator, *types.ValidatorSet, error) {
+	newVal, newPrivVal, err := Validator(ctx, 10)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var newVals *types.ValidatorSet
+	if nop {
+		newVals = types.NewValidatorSet(vals.Copy().Validators)
+	} else {
+		if vals.Size() > 2 {
+			newVals = types.NewValidatorSet(append(vals.Copy().Validators[:vals.Size()-1], newVal))
+		} else {
+			newVals = types.NewValidatorSet(append(vals.Copy().Validators, newVal))
+		}
+	}
+
+	// we need to sort the priv validators with the same index as the validator set
+	pv := make([]types.PrivValidator, newVals.Size())
+	for idx, val := range newVals.Validators {
+		found := false
+		for _, p := range append(privVals, newPrivVal.(types.MockPV)) {
+			if bytes.Equal(p.PrivKey.PubKey().Address(), val.Address) {
+				pv[idx] = p
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, nil, fmt.Errorf("missing priv validator for %v", val.Address)
+		}
+	}
+
+	return pv, newVals, nil
+}

--- a/testing/runner/latency_emulation.go
+++ b/testing/runner/latency_emulation.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"slices"
+
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
+)
+
+// tcCommands generates the content of a shell script that includes a list of tc
+// (traffic control) commands to emulate latency from the given node to all
+// other nodes in the testnet.
+func tcCommands(node *e2e.Node, infp infra.Provider) ([]string, error) {
+	allZones, zoneMatrix, err := e2e.LoadZoneLatenciesMatrix()
+	if err != nil {
+		return nil, err
+	}
+	nodeZoneIndex := slices.Index(allZones, node.Zone)
+
+	tcCmds := []string{
+		"#!/bin/sh",
+		"set -e",
+
+		// Delete any existing qdisc on the root of the eth0 interface.
+		"tc qdisc del dev eth0 root 2> /dev/null || true",
+
+		// Add a new root qdisc of type HTB with a default class of 10.
+		"tc qdisc add dev eth0 root handle 1: htb default 10",
+
+		// Add a root class with identifier 1:1 and a rate limit of 1 gigabit per second.
+		"tc class add dev eth0 parent 1: classid 1:1 htb rate 1gbit",
+
+		// Add a default class under the root class with identifier 1:10 and a rate limit of 1 gigabit per second.
+		"tc class add dev eth0 parent 1:1 classid 1:10 htb rate 1gbit",
+
+		// Add an SFQ qdisc to the default class with handle 10: to manage traffic with fairness.
+		"tc qdisc add dev eth0 parent 1:10 handle 10: sfq perturb 10",
+	}
+
+	// handle must be unique for each rule; start from one higher than last handle used above (10).
+	handle := 11
+	for _, targetZone := range allZones {
+		// Get latency from node's zone to target zone (note that the matrix is symmetric).
+		latency := zoneMatrix[targetZone][nodeZoneIndex]
+		if latency <= 0 {
+			continue
+		}
+
+		// Assign latency +/- 0.05% to handle.
+		delta := latency / 20
+		if delta == 0 {
+			// Zero is not allowed in normal distribution.
+			delta = 1
+		}
+
+		// Add a class with the calculated handle, under the root class, with the specified rate.
+		tcCmds = append(tcCmds, fmt.Sprintf("tc class add dev eth0 parent 1:1 classid 1:%d htb rate 1gbit", handle))
+
+		// Add a netem qdisc to simulate the specified delay with normal distribution.
+		tcCmds = append(tcCmds, fmt.Sprintf("tc qdisc add dev eth0 parent 1:%d handle %d: netem delay %dms %dms distribution normal", handle, handle, latency, delta))
+
+		// Set emulated latency to nodes in the target zone.
+		for _, otherNode := range node.Testnet.Nodes {
+			if otherNode.Zone == targetZone || node.Name == otherNode.Name {
+				continue
+			}
+			otherNodeIP := infp.NodeIP(otherNode)
+			// Assign latency handle to target node.
+			tcCmds = append(tcCmds, fmt.Sprintf("tc filter add dev eth0 protocol ip parent 1: prio 1 u32 match ip dst %s/32 flowid 1:%d", otherNodeIP, handle))
+		}
+
+		handle++
+	}
+
+	// Display tc configuration for debugging.
+	tcCmds = append(tcCmds, []string{
+		fmt.Sprintf("echo Traffic Control configuration on %s:", node.Name),
+		"tc qdisc show",
+		"tc class show dev eth0",
+		// "tc filter show dev eth0", // too verbose
+	}...)
+
+	return tcCmds, nil
+}

--- a/testing/runner/load.go
+++ b/testing/runner/load.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cometbft/cometbft/libs/log"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/test/loadtime/payload"
+	"github.com/cometbft/cometbft/types"
+	"github.com/google/uuid"
+)
+
+const workerPoolSize = 16
+
+// Load generates transactions against the network until the given context is
+// canceled.
+func Load(ctx context.Context, testnet *e2e.Testnet, useInternalIP bool) error {
+	initialTimeout := 1 * time.Minute
+	stallTimeout := 30 * time.Second
+	chSuccess := make(chan struct{})
+	chFailed := make(chan error)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	logger.Info("load", "msg", log.NewLazySprintf("Starting transaction load (%v workers)...", workerPoolSize))
+	started := time.Now()
+	u := [16]byte(uuid.New()) // generate run ID on startup
+
+	txCh := make(chan types.Tx)
+	go loadGenerate(ctx, txCh, testnet, u[:])
+
+	for _, n := range testnet.Nodes {
+		if n.SendNoLoad {
+			continue
+		}
+
+		for w := 0; w < testnet.LoadTxConnections; w++ {
+			go loadProcess(ctx, txCh, chSuccess, chFailed, n, useInternalIP)
+		}
+	}
+
+	// Monitor successful and failed transactions, and abort on stalls.
+	success, failed := 0, 0
+	errorCounter := make(map[string]int)
+	timeout := initialTimeout
+	for {
+		rate := log.NewLazySprintf("%.1f", float64(success)/time.Since(started).Seconds())
+
+		select {
+		case <-chSuccess:
+			success++
+			timeout = stallTimeout
+		case err := <-chFailed:
+			failed++
+			errorCounter[err.Error()]++
+		case <-time.After(timeout):
+			return fmt.Errorf("unable to submit transactions for %v", timeout)
+		case <-ctx.Done():
+			if success == 0 {
+				return errors.New("failed to submit any transactions")
+			}
+			logger.Info("load", "msg", log.NewLazySprintf("Ending transaction load after %v txs (%v tx/s)...", success, rate))
+			return nil
+		}
+
+		// Log every ~1 second the number of sent transactions.
+		total := success + failed
+		if total%testnet.LoadTxBatchSize == 0 {
+			successRate := float64(success) / float64(total)
+			logger.Debug("load", "success", success, "failed", failed, "success/total", log.NewLazySprintf("%.2f", successRate), "tx/s", rate)
+			if len(errorCounter) > 0 {
+				for err, c := range errorCounter {
+					if c == 1 {
+						logger.Error("failed to send transaction", "err", err)
+					} else {
+						logger.Error("failed to send multiple transactions", "count", c, "err", err)
+					}
+				}
+				errorCounter = make(map[string]int)
+			}
+		}
+
+		// Check if reached max number of allowed transactions to send.
+		if testnet.LoadMaxTxs > 0 && success >= testnet.LoadMaxTxs {
+			logger.Info("load", "msg", log.NewLazySprintf("Ending transaction load after reaching %v txs (%v tx/s)...", success, rate))
+			return nil
+		}
+	}
+}
+
+// loadGenerate generates jobs until the context is canceled.
+func loadGenerate(ctx context.Context, txCh chan<- types.Tx, testnet *e2e.Testnet, id []byte) {
+	t := time.NewTimer(0)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+		case <-ctx.Done():
+			close(txCh)
+			return
+		}
+		t.Reset(time.Second)
+
+		// A context with a timeout is created here to time the createTxBatch
+		// function out. If createTxBatch has not completed its work by the time
+		// the next batch is set to be sent out, then the context is canceled so that
+		// the current batch is halted, allowing the next batch to begin.
+		tctx, cf := context.WithTimeout(ctx, time.Second)
+		createTxBatch(tctx, txCh, testnet, id)
+		cf()
+	}
+}
+
+// createTxBatch creates new transactions and sends them into the txCh. createTxBatch
+// returns when either a full batch has been sent to the txCh or the context
+// is canceled.
+func createTxBatch(ctx context.Context, txCh chan<- types.Tx, testnet *e2e.Testnet, id []byte) {
+	wg := &sync.WaitGroup{}
+	genCh := make(chan struct{})
+	for i := 0; i < workerPoolSize; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range genCh {
+				tx, err := payload.NewBytes(&payload.Payload{
+					Id:          id,
+					Size:        uint64(testnet.LoadTxSizeBytes),
+					Rate:        uint64(testnet.LoadTxBatchSize),
+					Connections: uint64(testnet.LoadTxConnections),
+				})
+				if err != nil {
+					panic(fmt.Sprintf("Failed to generate tx: %v", err))
+				}
+
+				select {
+				case txCh <- tx:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+	for i := 0; i < testnet.LoadTxBatchSize; i++ {
+		select {
+		case genCh <- struct{}{}:
+		case <-ctx.Done():
+		}
+	}
+	close(genCh)
+	wg.Wait()
+}
+
+// loadProcess processes transactions by sending transactions received on the txCh
+// to the client.
+func loadProcess(ctx context.Context, txCh <-chan types.Tx, chSuccess chan<- struct{}, chFailed chan<- error, n *e2e.Node, useInternalIP bool) {
+	var client *rpchttp.HTTP
+	var err error
+	s := struct{}{}
+	for tx := range txCh {
+		if client == nil {
+			if useInternalIP {
+				client, err = n.ClientInternalIP()
+			} else {
+				client, err = n.Client()
+			}
+			if err != nil {
+				logger.Info("non-fatal error creating node client", "error", err)
+				continue
+			}
+		}
+		if _, err = client.BroadcastTxSync(ctx, tx); err != nil {
+			chFailed <- err
+			continue
+		}
+		chSuccess <- s
+	}
+}

--- a/testing/runner/main.go
+++ b/testing/runner/main.go
@@ -1,0 +1,430 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/cometbft/cometbft/libs/log"
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
+	"github.com/cometbft/cometbft/test/e2e/pkg/infra/digitalocean"
+	"github.com/cometbft/cometbft/test/e2e/pkg/infra/docker"
+	"github.com/spf13/cobra"
+)
+
+const randomSeed = 2308084734268
+
+var logger = log.NewTMLogger(log.NewSyncWriter(os.Stdout))
+
+func main() {
+	NewCLI().Run()
+}
+
+// CLI is the Cobra-based command-line interface.
+type CLI struct {
+	root     *cobra.Command
+	testnet  *e2e.Testnet
+	preserve bool
+	infp     infra.Provider
+}
+
+// NewCLI sets up the CLI.
+func NewCLI() *CLI {
+	cli := &CLI{}
+	cli.root = &cobra.Command{
+		Use:           "runner",
+		Short:         "End-to-end test runner",
+		SilenceUsage:  true,
+		SilenceErrors: true, // we'll output them ourselves in Run()
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			file, err := cmd.Flags().GetString("file")
+			if err != nil {
+				return err
+			}
+			m, err := e2e.LoadManifest(file)
+			if err != nil {
+				return err
+			}
+
+			inft, err := cmd.Flags().GetString("infrastructure-type")
+			if err != nil {
+				return err
+			}
+
+			var ifd e2e.InfrastructureData
+			switch inft {
+			case "docker":
+				var err error
+				ifd, err = e2e.NewDockerInfrastructureData(m)
+				if err != nil {
+					return err
+				}
+			case "digital-ocean":
+				p, err := cmd.Flags().GetString("infrastructure-data")
+				if err != nil {
+					return err
+				}
+				if p == "" {
+					return errors.New("'--infrastructure-data' must be set when using the 'digital-ocean' infrastructure-type")
+				}
+				ifd, err = e2e.InfrastructureDataFromFile(p)
+				if err != nil {
+					return fmt.Errorf("parsing infrastructure data: %s", err)
+				}
+			default:
+				return fmt.Errorf("unknown infrastructure type '%s'", inft)
+			}
+
+			testnetDir, err := cmd.Flags().GetString("testnet-dir")
+			if err != nil {
+				return err
+			}
+
+			testnet, err := e2e.LoadTestnet(file, ifd, testnetDir)
+			if err != nil {
+				return fmt.Errorf("loading testnet: %s", err)
+			}
+
+			cli.testnet = testnet
+			switch inft {
+			case "docker":
+				cli.infp = &docker.Provider{
+					ProviderData: infra.ProviderData{
+						Testnet:            testnet,
+						InfrastructureData: ifd,
+					},
+				}
+			case "digital-ocean":
+				cli.infp = &digitalocean.Provider{
+					ProviderData: infra.ProviderData{
+						Testnet:            testnet,
+						InfrastructureData: ifd,
+					},
+				}
+			default:
+				return fmt.Errorf("bad infrastructure type: %s", inft)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := Cleanup(cli.testnet); err != nil {
+				return err
+			}
+			if err := Setup(cli.testnet, cli.infp); err != nil {
+				return err
+			}
+
+			r := rand.New(rand.NewSource(randomSeed)) //nolint: gosec
+
+			chLoadResult := make(chan error)
+			ctx, loadCancel := context.WithCancel(context.Background())
+			defer loadCancel()
+			go func() {
+				err := Load(ctx, cli.testnet, false)
+				if err != nil {
+					logger.Error(fmt.Sprintf("Transaction load failed: %v", err.Error()))
+				}
+				chLoadResult <- err
+			}()
+
+			if err := Start(cmd.Context(), cli.testnet, cli.infp); err != nil {
+				return err
+			}
+
+			if err := Wait(cmd.Context(), cli.testnet, 5); err != nil { // allow some txs to go through
+				return err
+			}
+
+			if cli.testnet.HasPerturbations() {
+				if err := Perturb(cmd.Context(), cli.testnet, cli.infp); err != nil {
+					return err
+				}
+				if err := Wait(cmd.Context(), cli.testnet, 5); err != nil { // allow some txs to go through
+					return err
+				}
+			}
+
+			if cli.testnet.Evidence > 0 {
+				if err := InjectEvidence(ctx, r, cli.testnet, cli.testnet.Evidence); err != nil {
+					return err
+				}
+				if err := Wait(cmd.Context(), cli.testnet, 5); err != nil { // ensure chain progress
+					return err
+				}
+			}
+
+			loadCancel()
+			if err := <-chLoadResult; err != nil {
+				return err
+			}
+			if err := Wait(cmd.Context(), cli.testnet, 5); err != nil { // wait for network to settle before tests
+				return err
+			}
+			if err := Test(cli.testnet, cli.infp.GetInfrastructureData()); err != nil {
+				return err
+			}
+			if !cli.preserve {
+				if err := Cleanup(cli.testnet); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+
+	cli.root.PersistentFlags().StringP("file", "f", "", "Testnet TOML manifest")
+	_ = cli.root.MarkPersistentFlagRequired("file")
+
+	cli.root.PersistentFlags().StringP("testnet-dir", "d", "", "Set the directory for the testnet files generated during setup")
+
+	cli.root.PersistentFlags().StringP("infrastructure-type", "", "docker", "Backing infrastructure used to run the testnet. Either 'digital-ocean' or 'docker'")
+
+	cli.root.PersistentFlags().StringP("infrastructure-data", "", "", "path to the json file containing the infrastructure data. Only used if the 'infrastructure-type' is set to a value other than 'docker'")
+
+	cli.root.Flags().BoolVarP(&cli.preserve, "preserve", "p", false,
+		"Preserves the running of the test net after tests are completed")
+
+	cli.root.AddCommand(&cobra.Command{
+		Use:   "setup",
+		Short: "Generates the testnet directory and configuration",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return Setup(cli.testnet, cli.infp)
+		},
+	})
+
+	cli.root.AddCommand(&cobra.Command{
+		Use:   "start",
+		Short: "Starts the testnet, waiting for nodes to become available",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, err := os.Stat(cli.testnet.Dir)
+			if errors.Is(err, fs.ErrNotExist) {
+				err = Setup(cli.testnet, cli.infp)
+			}
+			if err != nil {
+				return err
+			}
+			return Start(cmd.Context(), cli.testnet, cli.infp)
+		},
+	})
+
+	cli.root.AddCommand(&cobra.Command{
+		Use:   "perturb",
+		Short: "Perturbs the testnet, e.g. by restarting or disconnecting nodes",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return Perturb(cmd.Context(), cli.testnet, cli.infp)
+		},
+	})
+
+	cli.root.AddCommand(&cobra.Command{
+		Use:   "wait",
+		Short: "Waits for a few blocks to be produced and all nodes to catch up",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return Wait(cmd.Context(), cli.testnet, 5)
+		},
+	})
+
+	cli.root.AddCommand(&cobra.Command{
+		Use:   "stop",
+		Short: "Stops the testnet",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			logger.Info("Stopping testnet")
+			return cli.infp.StopTestnet(context.Background())
+		},
+	})
+
+	var useInternalIP bool
+	loadCmd := &cobra.Command{
+		Use:   "load",
+		Short: "Generates transaction load until the command is canceled.",
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
+			useInternalIP, err = cmd.Flags().GetBool("internal-ip")
+			if err != nil {
+				return err
+			}
+			return Load(context.Background(), cli.testnet, useInternalIP)
+		},
+	}
+	loadCmd.PersistentFlags().BoolVar(&useInternalIP, "internal-ip", false,
+		"Use nodes' internal IP addresses when sending transaction load. For running from inside a DO private network.")
+	cli.root.AddCommand(loadCmd)
+
+	cli.root.AddCommand(&cobra.Command{
+		Use:   "evidence [amount]",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "Generates and broadcasts evidence to a random node",
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			amount := 1
+
+			if len(args) == 1 {
+				amount, err = strconv.Atoi(args[0])
+				if err != nil {
+					return err
+				}
+			}
+
+			return InjectEvidence(
+				cmd.Context(),
+				rand.New(rand.NewSource(randomSeed)), //nolint: gosec
+				cli.testnet,
+				amount,
+			)
+		},
+	})
+
+	cli.root.AddCommand(&cobra.Command{
+		Use:   "test",
+		Short: "Runs test cases against a running testnet",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return Test(cli.testnet, cli.infp.GetInfrastructureData())
+		},
+	})
+
+	monitorCmd := cobra.Command{
+		Use:     "monitor",
+		Aliases: []string{"mon"},
+		Short:   "Manage monitoring services such as Prometheus, Grafana, ElasticSearch, etc.",
+		Long: "Manage monitoring services such as Prometheus, Grafana, ElasticSearch, etc.\n" +
+			"First run 'setup' to generate a Prometheus config file.",
+	}
+	monitorStartCmd := cobra.Command{
+		Use:     "start",
+		Aliases: []string{"up"},
+		Short:   "Start monitoring services.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, err := os.Stat(PrometheusConfigFile)
+			if errors.Is(err, fs.ErrNotExist) {
+				return fmt.Errorf("file %s not found", PrometheusConfigFile)
+			}
+			if err := docker.ExecComposeVerbose(cmd.Context(), "monitoring", "up", "-d"); err != nil {
+				return err
+			}
+			logger.Info("Grafana: http://localhost:3000 ; Prometheus: http://localhost:9090")
+			return nil
+		},
+	}
+	monitorStopCmd := cobra.Command{
+		Use:     "stop",
+		Aliases: []string{"down"},
+		Short:   "Stop monitoring services.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, err := os.Stat(PrometheusConfigFile)
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
+			logger.Info("Shutting down monitoring services.")
+			if err := docker.ExecComposeVerbose(cmd.Context(), "monitoring", "down"); err != nil {
+				return err
+			}
+			// Remove prometheus config only when there is no testnet.
+			if _, err := os.Stat(cli.testnet.Dir); errors.Is(err, fs.ErrNotExist) {
+				if err := os.RemoveAll(PrometheusConfigFile); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	monitorCmd.AddCommand(&monitorStartCmd)
+	monitorCmd.AddCommand(&monitorStopCmd)
+	cli.root.AddCommand(&monitorCmd)
+
+	cli.root.AddCommand(&cobra.Command{
+		Use:     "cleanup",
+		Aliases: []string{"clean"},
+		Short:   "Removes the testnet directory",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Alert if monitoring services are still running.
+			outBytes, err := docker.ExecComposeOutput(cmd.Context(), "monitoring", "ps", "--services", "--filter", "status=running")
+			out := strings.TrimSpace(string(outBytes))
+			if err == nil && len(out) != 0 {
+				logger.Info("Monitoring services are still running:\n" + out)
+			}
+			return Cleanup(cli.testnet)
+		},
+	})
+
+	cli.root.AddCommand(&cobra.Command{
+		Use:   "logs",
+		Short: "Shows the testnet logs",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return docker.ExecComposeVerbose(context.Background(), cli.testnet.Dir, "logs")
+		},
+	})
+
+	cli.root.AddCommand(&cobra.Command{
+		Use:   "tail",
+		Short: "Tails the testnet logs",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return docker.ExecComposeVerbose(context.Background(), cli.testnet.Dir, "logs", "--follow")
+		},
+	})
+
+	cli.root.AddCommand(&cobra.Command{
+		Use:   "benchmark",
+		Short: "Benchmarks testnet",
+		Long: `Benchmarks the following metrics:
+	Mean Block Interval
+	Standard Deviation
+	Min Block Interval
+	Max Block Interval
+over a 100 block sampling period.
+		
+Does not run any perturbations.
+		`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := Cleanup(cli.testnet); err != nil {
+				return err
+			}
+			if err := Setup(cli.testnet, cli.infp); err != nil {
+				return err
+			}
+
+			chLoadResult := make(chan error)
+			ctx, loadCancel := context.WithCancel(cmd.Context())
+			defer loadCancel()
+			go func() {
+				err := Load(ctx, cli.testnet, false)
+				if err != nil {
+					logger.Error(fmt.Sprintf("Transaction load errored: %v", err.Error()))
+				}
+				chLoadResult <- err
+			}()
+
+			if err := Start(cmd.Context(), cli.testnet, cli.infp); err != nil {
+				return err
+			}
+
+			if err := Wait(cmd.Context(), cli.testnet, 5); err != nil { // allow some txs to go through
+				return err
+			}
+
+			// we benchmark performance over the next 100 blocks
+			if err := Benchmark(cmd.Context(), cli.testnet, 100); err != nil {
+				return err
+			}
+
+			loadCancel()
+			if err := <-chLoadResult; err != nil {
+				return err
+			}
+
+			return Cleanup(cli.testnet)
+		},
+	})
+
+	return cli
+}
+
+// Run runs the CLI.
+func (cli *CLI) Run() {
+	if err := cli.root.Execute(); err != nil {
+		logger.Error(err.Error())
+		os.Exit(1)
+	}
+}

--- a/testing/runner/perturb.go
+++ b/testing/runner/perturb.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cometbft/cometbft/libs/log"
+	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
+	"github.com/cometbft/cometbft/test/e2e/pkg/infra/docker"
+)
+
+// Perturbs a running testnet.
+func Perturb(ctx context.Context, testnet *e2e.Testnet, ifp infra.Provider) error {
+	for _, node := range testnet.Nodes {
+		for _, perturbation := range node.Perturbations {
+			_, err := PerturbNode(ctx, node, perturbation, ifp)
+			if err != nil {
+				return err
+			}
+			time.Sleep(3 * time.Second) // give network some time to recover between each
+		}
+	}
+	return nil
+}
+
+// PerturbNode perturbs a node with a given perturbation, returning its status
+// after recovering.
+func PerturbNode(ctx context.Context, node *e2e.Node, perturbation e2e.Perturbation, ifp infra.Provider) (*rpctypes.ResultStatus, error) {
+	testnet := node.Testnet
+
+	name, upgraded, err := ifp.CheckUpgraded(ctx, node)
+	if err != nil {
+		return nil, err
+	}
+	if upgraded {
+		logger.Info("perturb node", "msg",
+			log.NewLazySprintf("Node %v already upgraded, operating on alternate container %v",
+				node.Name, name))
+	}
+
+	timeout := 20 * time.Second
+
+	switch perturbation {
+	case e2e.PerturbationDisconnect:
+		logger.Info("perturb node", "msg", log.NewLazySprintf("Disconnecting node %v...", node.Name))
+		if err := ifp.Disconnect(context.Background(), name, node.ExternalIP.String()); err != nil {
+			return nil, err
+		}
+		time.Sleep(10 * time.Second)
+		if err := ifp.Reconnect(context.Background(), name, node.ExternalIP.String()); err != nil {
+			return nil, err
+		}
+
+	case e2e.PerturbationKill:
+		logger.Info("perturb node", "msg", log.NewLazySprintf("Killing node %v...", node.Name))
+		if err := docker.ExecCompose(context.Background(), testnet.Dir, "kill", "-s", "SIGKILL", name); err != nil {
+			return nil, err
+		}
+		if err := docker.ExecCompose(context.Background(), testnet.Dir, "start", name); err != nil {
+			return nil, err
+		}
+		if node.PersistInterval == 0 {
+			timeout *= 5
+		} else {
+			// still need to give some extra time to the runner
+			// to wait for the node to restart when killing
+			timeout *= 2
+		}
+
+	case e2e.PerturbationPause:
+		logger.Info("perturb node", "msg", log.NewLazySprintf("Pausing node %v...", node.Name))
+		if err := docker.ExecCompose(context.Background(), testnet.Dir, "pause", name); err != nil {
+			return nil, err
+		}
+		time.Sleep(10 * time.Second)
+		if err := docker.ExecCompose(context.Background(), testnet.Dir, "unpause", name); err != nil {
+			return nil, err
+		}
+
+	case e2e.PerturbationRestart:
+		logger.Info("perturb node", "msg", log.NewLazySprintf("Restarting node %v...", node.Name))
+		if err := docker.ExecCompose(context.Background(), testnet.Dir, "restart", name); err != nil {
+			return nil, err
+		}
+		if node.PersistInterval == 0 {
+			timeout *= 5
+		}
+
+	case e2e.PerturbationUpgrade:
+		oldV := node.Version
+		newV := node.Testnet.UpgradeVersion
+		if upgraded {
+			return nil, fmt.Errorf("node %v can't be upgraded twice from version '%v' to version '%v'",
+				node.Name, oldV, newV)
+		}
+		if oldV == newV {
+			logger.Info("perturb node", "msg",
+				log.NewLazySprintf("Skipping upgrade of node %v to version '%v'; versions are equal.",
+					node.Name, newV))
+			break
+		}
+		logger.Info("perturb node", "msg",
+			log.NewLazySprintf("Upgrading node %v from version '%v' to version '%v'...",
+				node.Name, oldV, newV))
+
+		if err := docker.ExecCompose(context.Background(), testnet.Dir, "stop", name); err != nil {
+			return nil, err
+		}
+		time.Sleep(10 * time.Second)
+		if err := docker.ExecCompose(context.Background(), testnet.Dir, "up", "-d", name+"_u"); err != nil {
+			return nil, err
+		}
+		if node.PersistInterval == 0 {
+			timeout *= 5
+		}
+
+	default:
+		return nil, fmt.Errorf("unexpected perturbation %q", perturbation)
+	}
+
+	status, err := waitForNode(ctx, node, 0, timeout)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("perturb node",
+		"msg",
+		log.NewLazySprintf("Node %v recovered at height %v", node.Name, status.SyncInfo.LatestBlockHeight))
+	return status, nil
+}

--- a/testing/runner/rpc.go
+++ b/testing/runner/rpc.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/types"
+)
+
+// waitForHeight waits for the network to reach a certain height (or above),
+// returning the highest height seen. Errors if the network is not making
+// progress at all.
+func waitForHeight(ctx context.Context, testnet *e2e.Testnet, height int64) (*types.Block, *types.BlockID, error) {
+	var (
+		err          error
+		maxResult    *rpctypes.ResultBlock
+		clients      = map[string]*rpchttp.HTTP{}
+		lastIncrease = time.Now()
+	)
+
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-timer.C:
+			for _, node := range testnet.Nodes {
+				if node.Stateless() {
+					continue
+				}
+				client, ok := clients[node.Name]
+				if !ok {
+					client, err = node.Client()
+					if err != nil {
+						continue
+					}
+					clients[node.Name] = client
+				}
+
+				subctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+				defer cancel()
+				result, err := client.Block(subctx, nil)
+				if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+					return nil, nil, ctx.Err()
+				}
+				if err != nil {
+					continue
+				}
+				if result.Block != nil && (maxResult == nil || result.Block.Height > maxResult.Block.Height) {
+					maxResult = result
+					lastIncrease = time.Now()
+				}
+				if maxResult != nil && maxResult.Block.Height >= height {
+					return maxResult.Block, &maxResult.BlockID, nil
+				}
+			}
+
+			if len(clients) == 0 {
+				return nil, nil, errors.New("unable to connect to any network nodes")
+			}
+			if time.Since(lastIncrease) >= 20*time.Second {
+				if maxResult == nil {
+					return nil, nil, errors.New("chain stalled at unknown height")
+				}
+				return nil, nil, fmt.Errorf("chain stalled at height %v", maxResult.Block.Height)
+			}
+			timer.Reset(1 * time.Second)
+		}
+	}
+}
+
+// waitForNode waits for a node to become available and catch up to the given block height.
+func waitForNode(ctx context.Context, node *e2e.Node, height int64, timeout time.Duration) (*rpctypes.ResultStatus, error) {
+	client, err := node.Client()
+	if err != nil {
+		return nil, err
+	}
+
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+	var curHeight int64
+	lastChanged := time.Now()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timer.C:
+			status, err := client.Status(ctx)
+			sinceLastChanged := time.Since(lastChanged)
+			switch {
+			case sinceLastChanged > timeout:
+				return nil, fmt.Errorf("waiting for node %v timed out: exceeded %v wait timeout after waiting for %v",
+					node.Name, timeout, sinceLastChanged)
+			case err != nil:
+			case status.SyncInfo.LatestBlockHeight >= height && (height == 0 || !status.SyncInfo.CatchingUp):
+				return status, nil
+			case curHeight < status.SyncInfo.LatestBlockHeight:
+				curHeight = status.SyncInfo.LatestBlockHeight
+				lastChanged = time.Now()
+			}
+
+			timer.Reset(300 * time.Millisecond)
+		}
+	}
+}
+
+// waitForAllNodes waits for all nodes to become available and catch up to the given block height.
+func waitForAllNodes(ctx context.Context, testnet *e2e.Testnet, height int64, timeout time.Duration) (int64, error) {
+	var lastHeight int64
+
+	deadline := time.Now().Add(timeout)
+
+	for _, node := range testnet.Nodes {
+		if node.Mode == e2e.ModeSeed {
+			continue
+		}
+
+		status, err := waitForNode(ctx, node, height, time.Until(deadline))
+		if err != nil {
+			return 0, err
+		}
+
+		if status.SyncInfo.LatestBlockHeight > lastHeight {
+			lastHeight = status.SyncInfo.LatestBlockHeight
+		}
+	}
+
+	return lastHeight, nil
+}

--- a/testing/runner/setup.go
+++ b/testing/runner/setup.go
@@ -1,0 +1,498 @@
+package main
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	beaconkitconsensus "github.com/berachain/beacon-kit/consensus/cometbft/service"
+	"github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	"github.com/cometbft/cometbft/libs/log"
+	"github.com/cometbft/cometbft/p2p"
+	"github.com/cometbft/cometbft/privval"
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
+	"github.com/cometbft/cometbft/types"
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/spf13/viper"
+)
+
+const (
+	AppAddressTCP  = "tcp://127.0.0.1:30000"
+	AppAddressUNIX = "unix:///var/run/app.sock"
+
+	PrivvalAddressTCP     = "tcp://0.0.0.0:27559"
+	PrivvalAddressUNIX    = "unix:///var/run/privval.sock"
+	PrivvalKeyFile        = "config/priv_validator_key.json"
+	PrivvalStateFile      = "data/priv_validator_state.json"
+	PrivvalDummyKeyFile   = "config/dummy_validator_key.json"
+	PrivvalDummyStateFile = "data/dummy_validator_state.json"
+
+	PrometheusConfigFile = "monitoring/prometheus.yml"
+)
+
+// Setup sets up the testnet configuration.
+func Setup(testnet *e2e.Testnet, infp infra.Provider) error {
+	logger.Info("setup", "msg", log.NewLazySprintf("Generating testnet files in %#q", testnet.Dir))
+
+	if err := os.MkdirAll(testnet.Dir, os.ModePerm); err != nil {
+		return err
+	}
+
+	genesis, err := MakeGenesis(testnet)
+	if err != nil {
+		return err
+	}
+
+	for _, node := range testnet.Nodes {
+		nodeDir := filepath.Join(testnet.Dir, node.Name)
+
+		dirs := []string{
+			filepath.Join(nodeDir, "config"),
+			filepath.Join(nodeDir, "data"),
+			filepath.Join(nodeDir, "data", "app"),
+		}
+		for _, dir := range dirs {
+			// light clients don't need an app directory
+			if node.Mode == e2e.ModeLight && strings.Contains(dir, "app") {
+				continue
+			}
+			err := os.MkdirAll(dir, 0o755)
+			if err != nil {
+				return err
+			}
+		}
+
+		cfg, err := MakeConfig(node)
+		if err != nil {
+			return err
+		}
+		config.WriteConfigFile(filepath.Join(nodeDir, "config", "config.toml"), cfg) // panics
+
+		appCfg, err := MakeAppConfig(node)
+		if err != nil {
+			return err
+		}
+		err = os.WriteFile(filepath.Join(nodeDir, "config", "app.toml"), appCfg, 0o644) //nolint:gosec
+		if err != nil {
+			return err
+		}
+
+		if node.Mode == e2e.ModeLight {
+			// stop early if a light client
+			continue
+		}
+
+		err = genesis.SaveAs(filepath.Join(nodeDir, "config", "genesis.json"))
+		if err != nil {
+			return err
+		}
+
+		err = (&p2p.NodeKey{PrivKey: node.NodeKey}).SaveAs(filepath.Join(nodeDir, "config", "node_key.json"))
+		if err != nil {
+			return err
+		}
+
+		(privval.NewFilePV(node.PrivvalKey,
+			filepath.Join(nodeDir, PrivvalKeyFile),
+			filepath.Join(nodeDir, PrivvalStateFile),
+		)).Save()
+
+		// Set up a dummy validator. CometBFT requires a file PV even when not used, so we
+		// give it a dummy such that it will fail if it actually tries to use it.
+		(privval.NewFilePV(ed25519.GenPrivKey(),
+			filepath.Join(nodeDir, PrivvalDummyKeyFile),
+			filepath.Join(nodeDir, PrivvalDummyStateFile),
+		)).Save()
+
+		if testnet.LatencyEmulationEnabled {
+			// Generate a shell script file containing tc (traffic control) commands
+			// to emulate latency to other nodes.
+			tcCmds, err := tcCommands(node, infp)
+			if err != nil {
+				return err
+			}
+			latencyPath := filepath.Join(nodeDir, "emulate-latency.sh")
+			//nolint: gosec // G306: Expect WriteFile permissions to be 0600 or less
+			if err = os.WriteFile(latencyPath, []byte(strings.Join(tcCmds, "\n")), 0o755); err != nil {
+				return err
+			}
+		}
+	}
+
+	if testnet.Prometheus {
+		if err := WritePrometheusConfig(testnet, PrometheusConfigFile); err != nil {
+			return err
+		}
+		// Make a copy of the Prometheus config file in the testnet directory.
+		// This should be temporary to keep it compatible with the qa-infra
+		// repository.
+		if err := WritePrometheusConfig(testnet, filepath.Join(testnet.Dir, "prometheus.yml")); err != nil {
+			return err
+		}
+	}
+
+	//nolint: revive
+	if err := infp.Setup(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// MakeGenesis generates a genesis document.
+func MakeGenesis(testnet *e2e.Testnet) (types.GenesisDoc, error) {
+	genesis := types.GenesisDoc{
+		GenesisTime:     time.Now(),
+		ChainID:         testnet.Name,
+		ConsensusParams: types.DefaultConsensusParams(),
+		InitialHeight:   testnet.InitialHeight,
+	}
+	// set the app version to 1
+	genesis.ConsensusParams.Version.App = 1
+	genesis.ConsensusParams.Evidence.MaxAgeNumBlocks = e2e.EvidenceAgeHeight
+	genesis.ConsensusParams.Evidence.MaxAgeDuration = e2e.EvidenceAgeTime
+	if testnet.BlockMaxBytes != 0 {
+		genesis.ConsensusParams.Block.MaxBytes = testnet.BlockMaxBytes
+	}
+	if testnet.VoteExtensionsUpdateHeight == -1 {
+		genesis.ConsensusParams.Feature.VoteExtensionsEnableHeight = testnet.VoteExtensionsEnableHeight
+	}
+	if testnet.PbtsUpdateHeight == -1 {
+		genesis.ConsensusParams.Feature.PbtsEnableHeight = testnet.PbtsEnableHeight
+	}
+	for validator, power := range testnet.Validators {
+		genesis.Validators = append(genesis.Validators, types.GenesisValidator{
+			Name:    validator.Name,
+			Address: validator.PrivvalKey.PubKey().Address(),
+			PubKey:  validator.PrivvalKey.PubKey(),
+			Power:   power,
+		})
+	}
+	// The validator set will be sorted internally by CometBFT ranked by power,
+	// but we sort it here as well so that all genesis files are identical.
+	sort.Slice(genesis.Validators, func(i, j int) bool {
+		return strings.Compare(genesis.Validators[i].Name, genesis.Validators[j].Name) == -1
+	})
+	if len(testnet.InitialState) > 0 {
+		appState, err := json.Marshal(testnet.InitialState)
+		if err != nil {
+			return genesis, err
+		}
+		genesis.AppState = appState
+	}
+
+	// Customized genesis fields provided in the manifest
+	if len(testnet.Genesis) > 0 {
+		v := viper.New()
+		v.SetConfigType("json")
+
+		for _, field := range testnet.Genesis {
+			key, value, err := e2e.ParseKeyValueField("genesis", field)
+			if err != nil {
+				return genesis, err
+			}
+			logger.Debug("Applying 'genesis' field", key, value)
+			v.Set(key, value)
+		}
+
+		// We use viper because it leaves untouched keys that are not set.
+		// The GenesisDoc does not use the original `mapstructure` tag.
+		err := v.Unmarshal(&genesis, func(d *mapstructure.DecoderConfig) {
+			d.TagName = "json"
+			d.ErrorUnused = true
+		})
+		if err != nil {
+			return genesis, fmt.Errorf("failed parsing 'genesis' field: %v", err)
+		}
+	}
+
+	return genesis, genesis.ValidateAndComplete()
+}
+
+// MakeConfig generates a CometBFT config for a node.
+func MakeConfig(node *e2e.Node) (*config.Config, error) {
+	cfg := beaconkitconsensus.DefaultConfig()
+	cfg.Moniker = node.Name
+	cfg.ProxyApp = AppAddressTCP
+
+	cfg.RPC.ListenAddress = "tcp://0.0.0.0:26657"
+	cfg.RPC.PprofListenAddress = ":6060"
+
+	cfg.GRPC.ListenAddress = "tcp://0.0.0.0:26670"
+	cfg.GRPC.VersionService.Enabled = true
+	cfg.GRPC.BlockService.Enabled = true
+	cfg.GRPC.BlockResultsService.Enabled = true
+
+	cfg.P2P.ExternalAddress = fmt.Sprintf("tcp://%v", node.AddressP2P(false))
+	cfg.P2P.AddrBookStrict = false
+
+	cfg.DBBackend = node.Database
+	cfg.StateSync.DiscoveryTime = 5 * time.Second
+	cfg.BlockSync.Version = node.BlockSyncVersion
+	cfg.Consensus.PeerGossipIntraloopSleepDuration = node.Testnet.PeerGossipIntraloopSleepDuration
+	cfg.Mempool.ExperimentalMaxGossipConnectionsToNonPersistentPeers = int(node.Testnet.ExperimentalMaxGossipConnectionsToNonPersistentPeers)
+	cfg.Mempool.ExperimentalMaxGossipConnectionsToPersistentPeers = int(node.Testnet.ExperimentalMaxGossipConnectionsToPersistentPeers)
+
+	// Assume that full nodes and validators will have a data companion
+	// attached, which will need access to the privileged gRPC endpoint.
+	if (node.Mode == e2e.ModeValidator || node.Mode == e2e.ModeFull) && node.EnableCompanionPruning {
+		cfg.Storage.Pruning.DataCompanion.Enabled = true
+		cfg.Storage.Pruning.DataCompanion.InitialBlockRetainHeight = 0
+		cfg.Storage.Pruning.DataCompanion.InitialBlockResultsRetainHeight = 0
+		cfg.GRPC.Privileged.ListenAddress = "tcp://0.0.0.0:26671"
+		cfg.GRPC.Privileged.PruningService.Enabled = true
+	}
+
+	switch node.ABCIProtocol {
+	case e2e.ProtocolUNIX:
+		cfg.ProxyApp = AppAddressUNIX
+	case e2e.ProtocolTCP:
+		cfg.ProxyApp = AppAddressTCP
+	case e2e.ProtocolGRPC:
+		cfg.ProxyApp = AppAddressTCP
+		cfg.ABCI = "grpc"
+	case e2e.ProtocolBuiltin, e2e.ProtocolBuiltinConnSync:
+		cfg.ProxyApp = ""
+		cfg.ABCI = ""
+	default:
+		return nil, fmt.Errorf("unexpected ABCI protocol setting %q", node.ABCIProtocol)
+	}
+
+	// CometBFT errors if it does not have a privval key set up, regardless of whether
+	// it's actually needed (e.g. for remote KMS or non-validators). We set up a dummy
+	// key here by default, and use the real key for actual validators that should use
+	// the file privval.
+	cfg.PrivValidatorListenAddr = ""
+	cfg.PrivValidatorKey = PrivvalDummyKeyFile
+	cfg.PrivValidatorState = PrivvalDummyStateFile
+
+	switch node.Mode {
+	case e2e.ModeValidator:
+		switch node.PrivvalProtocol {
+		case e2e.ProtocolFile:
+			cfg.PrivValidatorKey = PrivvalKeyFile
+			cfg.PrivValidatorState = PrivvalStateFile
+		case e2e.ProtocolUNIX:
+			cfg.PrivValidatorListenAddr = PrivvalAddressUNIX
+		case e2e.ProtocolTCP:
+			cfg.PrivValidatorListenAddr = PrivvalAddressTCP
+		default:
+			return nil, fmt.Errorf("invalid privval protocol setting %q", node.PrivvalProtocol)
+		}
+	case e2e.ModeSeed:
+		cfg.P2P.SeedMode = true
+		cfg.P2P.PexReactor = true
+	case e2e.ModeFull, e2e.ModeLight:
+		// Don't need to do anything, since we're using a dummy privval key by default.
+	default:
+		return nil, fmt.Errorf("unexpected mode %q", node.Mode)
+	}
+
+	if node.StateSync {
+		cfg.StateSync.Enable = true
+		cfg.StateSync.RPCServers = []string{}
+		for _, peer := range node.Testnet.ArchiveNodes() {
+			if peer.Name == node.Name {
+				continue
+			}
+			cfg.StateSync.RPCServers = append(cfg.StateSync.RPCServers, peer.AddressRPC())
+		}
+		if len(cfg.StateSync.RPCServers) < 2 {
+			return nil, errors.New("unable to find 2 suitable state sync RPC servers")
+		}
+	}
+
+	cfg.P2P.Seeds = ""
+	for _, seed := range node.Seeds {
+		if len(cfg.P2P.Seeds) > 0 {
+			cfg.P2P.Seeds += ","
+		}
+		cfg.P2P.Seeds += seed.AddressP2P(true)
+	}
+	cfg.P2P.PersistentPeers = ""
+	for _, peer := range node.PersistentPeers {
+		if len(cfg.P2P.PersistentPeers) > 0 {
+			cfg.P2P.PersistentPeers += ","
+		}
+		cfg.P2P.PersistentPeers += peer.AddressP2P(true)
+	}
+	if node.Testnet.DisablePexReactor {
+		cfg.P2P.PexReactor = false
+	}
+
+	if node.Testnet.LogLevel != "" {
+		cfg.LogLevel = node.Testnet.LogLevel
+	}
+
+	if node.Testnet.LogFormat != "" {
+		cfg.LogFormat = node.Testnet.LogFormat
+	}
+
+	if node.Prometheus {
+		cfg.Instrumentation.Prometheus = true
+	}
+
+	if node.ExperimentalKeyLayout != "" {
+		cfg.Storage.ExperimentalKeyLayout = node.ExperimentalKeyLayout
+	}
+
+	if node.Compact {
+		cfg.Storage.Compact = node.Compact
+	}
+
+	if node.DiscardABCIResponses {
+		cfg.Storage.DiscardABCIResponses = node.DiscardABCIResponses
+	}
+
+	if node.Indexer != "" {
+		cfg.TxIndex.Indexer = node.Indexer
+	}
+
+	if node.CompactionInterval != 0 && node.Compact {
+		cfg.Storage.CompactionInterval = node.CompactionInterval
+	}
+
+	// We currently need viper in order to parse config files.
+	if len(node.Config) > 0 {
+		v := viper.New()
+		for _, field := range node.Config {
+			key, value, err := e2e.ParseKeyValueField("config", field)
+			if err != nil {
+				return nil, err
+			}
+			logger.Debug("Applying 'config' field", "node", node.Name, key, value)
+			v.Set(key, value)
+		}
+		err := v.Unmarshal(cfg, func(d *mapstructure.DecoderConfig) {
+			d.ErrorUnused = true
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing 'config' field of node %v: %v", node.Name, err)
+		}
+	}
+
+	return cfg, nil
+}
+
+// MakeAppConfig generates an ABCI application config for a node.
+func MakeAppConfig(node *e2e.Node) ([]byte, error) {
+	cfg := map[string]any{
+		"chain_id":                      node.Testnet.Name,
+		"dir":                           "data/app",
+		"listen":                        AppAddressUNIX,
+		"mode":                          node.Mode,
+		"protocol":                      "socket",
+		"persist_interval":              node.PersistInterval,
+		"snapshot_interval":             node.SnapshotInterval,
+		"retain_blocks":                 node.RetainBlocks,
+		"key_type":                      node.PrivvalKey.Type(),
+		"prepare_proposal_delay":        node.Testnet.PrepareProposalDelay,
+		"process_proposal_delay":        node.Testnet.ProcessProposalDelay,
+		"check_tx_delay":                node.Testnet.CheckTxDelay,
+		"vote_extension_delay":          node.Testnet.VoteExtensionDelay,
+		"finalize_block_delay":          node.Testnet.FinalizeBlockDelay,
+		"vote_extension_size":           node.Testnet.VoteExtensionSize,
+		"vote_extensions_enable_height": node.Testnet.VoteExtensionsEnableHeight,
+		"vote_extensions_update_height": node.Testnet.VoteExtensionsUpdateHeight,
+		"abci_requests_logging_enabled": node.Testnet.ABCITestsEnabled,
+		"pbts_enable_height":            node.Testnet.PbtsEnableHeight,
+		"pbts_update_height":            node.Testnet.PbtsUpdateHeight,
+	}
+	switch node.ABCIProtocol {
+	case e2e.ProtocolUNIX:
+		cfg["listen"] = AppAddressUNIX
+	case e2e.ProtocolTCP:
+		cfg["listen"] = AppAddressTCP
+	case e2e.ProtocolGRPC:
+		cfg["listen"] = AppAddressTCP
+		cfg["protocol"] = "grpc"
+	case e2e.ProtocolBuiltin, e2e.ProtocolBuiltinConnSync:
+		delete(cfg, "listen")
+		cfg["protocol"] = string(node.ABCIProtocol)
+	default:
+		return nil, fmt.Errorf("unexpected ABCI protocol setting %q", node.ABCIProtocol)
+	}
+	if node.Mode == e2e.ModeValidator {
+		switch node.PrivvalProtocol {
+		case e2e.ProtocolFile:
+		case e2e.ProtocolTCP:
+			cfg["privval_server"] = PrivvalAddressTCP
+			cfg["privval_key"] = PrivvalKeyFile
+			cfg["privval_state"] = PrivvalStateFile
+		case e2e.ProtocolUNIX:
+			cfg["privval_server"] = PrivvalAddressUNIX
+			cfg["privval_key"] = PrivvalKeyFile
+			cfg["privval_state"] = PrivvalStateFile
+		default:
+			return nil, fmt.Errorf("unexpected privval protocol setting %q", node.PrivvalProtocol)
+		}
+	}
+
+	if len(node.Testnet.ValidatorUpdates) > 0 {
+		validatorUpdates := map[string]map[string]int64{}
+		for height, validators := range node.Testnet.ValidatorUpdates {
+			updateVals := map[string]int64{}
+			for node, power := range validators {
+				updateVals[base64.StdEncoding.EncodeToString(node.PrivvalKey.PubKey().Bytes())] = power
+			}
+			validatorUpdates[strconv.FormatInt(height, 10)] = updateVals
+		}
+		cfg["validator_update"] = validatorUpdates
+	}
+
+	var buf bytes.Buffer
+	err := toml.NewEncoder(&buf).Encode(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate app config: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+//go:embed templates/prometheus-yml.tmpl
+var prometheusYamlTemplate string
+
+func WritePrometheusConfig(testnet *e2e.Testnet, path string) error {
+	tmpl, err := template.New("prometheus-yaml").Parse(prometheusYamlTemplate)
+	if err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, testnet)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(path, buf.Bytes(), 0o644) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// UpdateConfigStateSync updates the state sync config for a node.
+func UpdateConfigStateSync(node *e2e.Node, height int64, hash []byte) error {
+	cfgPath := filepath.Join(node.Testnet.Dir, node.Name, "config", "config.toml")
+
+	// FIXME Apparently there's no function to simply load a config file without
+	// involving the entire Viper apparatus, so we'll just resort to regexps.
+	bz, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return err
+	}
+	bz = regexp.MustCompile(`(?m)^trust_height =.*`).ReplaceAll(bz, []byte(fmt.Sprintf(`trust_height = %v`, height)))
+	bz = regexp.MustCompile(`(?m)^trust_hash =.*`).ReplaceAll(bz, []byte(fmt.Sprintf(`trust_hash = "%X"`, hash)))
+	return os.WriteFile(cfgPath, bz, 0o644) //nolint:gosec
+}

--- a/testing/runner/start.go
+++ b/testing/runner/start.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/cometbft/cometbft/libs/log"
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
+)
+
+func Start(ctx context.Context, testnet *e2e.Testnet, p infra.Provider) error {
+	if len(testnet.Nodes) == 0 {
+		return errors.New("no nodes in testnet")
+	}
+
+	// Nodes are already sorted by name. Sort them by name then startAt,
+	// which gives the overall order startAt, mode, name.
+	nodeQueue := testnet.Nodes
+	sort.SliceStable(nodeQueue, func(i, j int) bool {
+		a, b := nodeQueue[i], nodeQueue[j]
+		switch {
+		case a.Mode == b.Mode:
+			return false
+		case a.Mode == e2e.ModeSeed:
+			return true
+		case a.Mode == e2e.ModeValidator && b.Mode == e2e.ModeFull:
+			return true
+		}
+		return false
+	})
+
+	sort.SliceStable(nodeQueue, func(i, j int) bool {
+		return nodeQueue[i].StartAt < nodeQueue[j].StartAt
+	})
+
+	if nodeQueue[0].StartAt > 0 {
+		return errors.New("no initial nodes in testnet")
+	}
+
+	// Start initial nodes (StartAt: 0)
+	logger.Info("Starting initial network nodes...")
+	nodesAtZero := make([]*e2e.Node, 0)
+	for len(nodeQueue) > 0 && nodeQueue[0].StartAt == 0 {
+		nodesAtZero = append(nodesAtZero, nodeQueue[0])
+		nodeQueue = nodeQueue[1:]
+	}
+	err := p.StartNodes(context.Background(), nodesAtZero...)
+	if err != nil {
+		return err
+	}
+	for _, node := range nodesAtZero {
+		if _, err := waitForNode(ctx, node, 0, 15*time.Second); err != nil {
+			return err
+		}
+		if node.PrometheusProxyPort > 0 {
+			logger.Info("start", "msg",
+				log.NewLazySprintf("Node %v up on http://%s:%v; with Prometheus on http://%s:%v/metrics",
+					node.Name, node.ExternalIP, node.RPCProxyPort, node.ExternalIP, node.PrometheusProxyPort),
+			)
+		} else {
+			logger.Info("start", "msg", log.NewLazySprintf("Node %v up on http://%s:%v",
+				node.Name, node.ExternalIP, node.RPCProxyPort))
+		}
+	}
+
+	networkHeight := testnet.InitialHeight
+
+	// Wait for initial height
+	logger.Info("Waiting for initial height",
+		"height", networkHeight,
+		"nodes", len(testnet.Nodes)-len(nodeQueue),
+		"pending", len(nodeQueue))
+
+	block, blockID, err := waitForHeight(ctx, testnet, networkHeight)
+	if err != nil {
+		return err
+	}
+
+	// Update any state sync nodes with a trusted height and hash
+	for _, node := range nodeQueue {
+		if node.StateSync || node.Mode == e2e.ModeLight {
+			err = UpdateConfigStateSync(node, block.Height, blockID.Hash.Bytes())
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, node := range nodeQueue {
+		if node.StartAt > networkHeight {
+			// if we're starting a node that's ahead of
+			// the last known height of the network, then
+			// we should make sure that the rest of the
+			// network has reached at least the height
+			// that this node will start at before we
+			// start the node.
+
+			networkHeight = node.StartAt
+
+			logger.Info("Waiting for network to advance before starting catch up node",
+				"node", node.Name,
+				"height", networkHeight)
+
+			if _, _, err := waitForHeight(ctx, testnet, networkHeight); err != nil {
+				return err
+			}
+		}
+
+		logger.Info("Starting catch up node", "node", node.Name, "height", node.StartAt)
+
+		err := p.StartNodes(context.Background(), node)
+		if err != nil {
+			return err
+		}
+		status, err := waitForNode(ctx, node, node.StartAt, 3*time.Minute)
+		if err != nil {
+			return err
+		}
+		if node.PrometheusProxyPort > 0 {
+			logger.Info("start", "msg", log.NewLazySprintf("Node %v up on http://%s:%v at height %v; with Prometheus on http://%s:%v/metrics",
+				node.Name, node.ExternalIP, node.RPCProxyPort, status.SyncInfo.LatestBlockHeight, node.ExternalIP, node.PrometheusProxyPort))
+		} else {
+			logger.Info("start", "msg", log.NewLazySprintf("Node %v up on http://%s:%v at height %v",
+				node.Name, node.ExternalIP, node.RPCProxyPort, status.SyncInfo.LatestBlockHeight))
+		}
+	}
+
+	return nil
+}

--- a/testing/runner/templates/prometheus-yml.tmpl
+++ b/testing/runner/templates/prometheus-yml.tmpl
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 1s
+
+scrape_configs:
+{{- range .Nodes }}
+  - job_name: '{{ .Name }}'
+    static_configs:
+      - targets: ['localhost:{{ .PrometheusProxyPort }}','host.docker.internal:{{ .PrometheusProxyPort }}']
+{{end}}

--- a/testing/runner/test.go
+++ b/testing/runner/test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+	"github.com/cometbft/cometbft/test/e2e/pkg/exec"
+)
+
+// Test runs test cases under tests.
+func Test(testnet *e2e.Testnet, ifd *e2e.InfrastructureData) error {
+	err := os.Setenv("E2E_MANIFEST", testnet.File)
+	if err != nil {
+		return err
+	}
+	err = os.Setenv("E2E_TESTNET_DIR", testnet.Dir)
+	if err != nil {
+		return err
+	}
+	if p := ifd.Path; p != "" {
+		err = os.Setenv("INFRASTRUCTURE_FILE", p)
+		if err != nil {
+			return err
+		}
+	}
+	err = os.Setenv("INFRASTRUCTURE_TYPE", ifd.Provider)
+	if err != nil {
+		return err
+	}
+
+	cmd := []string{"go", "test", "-count", "1"}
+	verbose := os.Getenv("VERBOSE")
+	if verbose == "1" {
+		cmd = append(cmd, "-v")
+	}
+	cmd = append(cmd, "./tests/...")
+
+	tests := "all tests"
+	runTest := os.Getenv("RUN_TEST")
+	if len(runTest) != 0 {
+		cmd = append(cmd, "-run", runTest)
+		tests = fmt.Sprintf("%q", runTest)
+	}
+
+	logger.Info(fmt.Sprintf("Running %s in ./tests/...", tests))
+
+	return exec.CommandVerbose(context.Background(), cmd...)
+}

--- a/testing/runner/wait.go
+++ b/testing/runner/wait.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/cometbft/cometbft/libs/log"
+	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
+)
+
+// Wait waits for a number of blocks to be produced, and for all nodes to catch
+// up with it.
+func Wait(ctx context.Context, testnet *e2e.Testnet, blocks int64) error {
+	block, _, err := waitForHeight(ctx, testnet, 0)
+	if err != nil {
+		return err
+	}
+	return WaitUntil(ctx, testnet, block.Height+blocks)
+}
+
+// WaitUntil waits until a given height has been reached.
+func WaitUntil(ctx context.Context, testnet *e2e.Testnet, height int64) error {
+	logger.Info("wait until", "msg", log.NewLazySprintf("Waiting for all nodes to reach height %v...", height))
+	_, err := waitForAllNodes(ctx, testnet, height, waitingTime(len(testnet.Nodes), height))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// waitingTime estimates how long it should take for a node to reach the height.
+// More nodes in a network implies we may expect a slower network and may have to wait longer.
+func waitingTime(nodes int, height int64) time.Duration {
+	return time.Duration(20+(int64(nodes)*height)) * time.Second
+}


### PR DESCRIPTION
Closes https://github.com/informalsystems/security-partner-internal-pm/issues/78
[ext][Berachain] Change configuration generation in runner to generate beacond-compatible config

> Please rebase it on greg/e2e-framework, once #2 is merged.

* Introduce runner
  * Copied from https://github.com/berachain/cometbft/commit/c547460c which is the version defined in beaconkit's `go.mod`
  * Add functions `Validator` and `MakeCommitFromVoteSet` from the `internal/tests` package to evidence handling.
  * Update `mapstructure` as beaconkit uses a newer version of viper than CometBFT and the new version is not compatible.
  * Change the `makeConfig` function to use beaconkit's DefaultConfig, instead of CometBFT.
(A diff between the cometbft branch and this code will show the differences nicely.)
* Add build script and testing script to the Makefile, and supporting files.

Note: There is a newer version of the runner in the main branch of berachain/cometbft, but beaconkit does not use the latest version.