### PR TITLE
override makeGenesis in runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,4 @@ temp-test-unit-cover.txt
 
 # e2e framework
 monitoring/
+testing/networks/single/

--- a/cli/commands/genesis/payload.go
+++ b/cli/commands/genesis/payload.go
@@ -107,7 +107,7 @@ func AddExecutionPayload(chainSpec ChainSpec, elGenesisPath string, config *cmtc
 		return errors.Wrap(err, "failed to unmarshal beacon state")
 	}
 	// Inject the execution payload.
-	eph, err := ExecutableDataToExecutionPayloadHeader(
+	eph, err := executableDataToExecutionPayloadHeader(
 		chainSpec.GenesisForkVersion(),
 		payload,
 		chainSpec.MaxWithdrawalsPerPayload(),
@@ -134,9 +134,24 @@ func AddExecutionPayload(chainSpec ChainSpec, elGenesisPath string, config *cmtc
 	return genutil.ExportGenesisFile(appGenesis, config.GenesisFile())
 }
 
+func PublicExecutableDataToExecutionPayloadHeader(forkVersion common.Version,
+	data *gethprimitives.ExecutableData,
+	// todo: re-enable when codec supports.
+	unused uint64,
+) (*types.ExecutionPayloadHeader, error) {
+	// This function is a public version of executableDataToExecutionPayloadHeader
+	// that does not require the context of the CLI command.
+	// It is used to convert the eth executable data type to the beacon execution}
+
+	return executableDataToExecutionPayloadHeader(
+		forkVersion,
+		data, unused)
+
+}
+
 // Converts the eth executable data type to the beacon execution payload header
 // interface.
-func ExecutableDataToExecutionPayloadHeader(
+func executableDataToExecutionPayloadHeader(
 	forkVersion common.Version,
 	data *gethprimitives.ExecutableData,
 	// todo: re-enable when codec supports.

--- a/cli/commands/genesis/payload.go
+++ b/cli/commands/genesis/payload.go
@@ -107,7 +107,7 @@ func AddExecutionPayload(chainSpec ChainSpec, elGenesisPath string, config *cmtc
 		return errors.Wrap(err, "failed to unmarshal beacon state")
 	}
 	// Inject the execution payload.
-	eph, err := executableDataToExecutionPayloadHeader(
+	eph, err := ExecutableDataToExecutionPayloadHeader(
 		chainSpec.GenesisForkVersion(),
 		payload,
 		chainSpec.MaxWithdrawalsPerPayload(),
@@ -136,7 +136,7 @@ func AddExecutionPayload(chainSpec ChainSpec, elGenesisPath string, config *cmtc
 
 // Converts the eth executable data type to the beacon execution payload header
 // interface.
-func executableDataToExecutionPayloadHeader(
+func ExecutableDataToExecutionPayloadHeader(
 	forkVersion common.Version,
 	data *gethprimitives.ExecutableData,
 	// todo: re-enable when codec supports.

--- a/cli/commands/genesis/payload.go
+++ b/cli/commands/genesis/payload.go
@@ -134,7 +134,7 @@ func AddExecutionPayload(chainSpec ChainSpec, elGenesisPath string, config *cmtc
 	return genutil.ExportGenesisFile(appGenesis, config.GenesisFile())
 }
 
-func PublicExecutableDataToExecutionPayloadHeader(forkVersion common.Version,
+func ExecutableDataToExecutionPayloadHeader(forkVersion common.Version,
 	data *gethprimitives.ExecutableData,
 	// todo: re-enable when codec supports.
 	unused uint64,

--- a/cli/commands/genesis/payload.go
+++ b/cli/commands/genesis/payload.go
@@ -134,6 +134,7 @@ func AddExecutionPayload(chainSpec ChainSpec, elGenesisPath string, config *cmtc
 	return genutil.ExportGenesisFile(appGenesis, config.GenesisFile())
 }
 
+// Exported function to convert the eth executable data type to the beacon execution
 func ExecutableDataToExecutionPayloadHeader(forkVersion common.Version,
 	data *gethprimitives.ExecutableData,
 	// todo: re-enable when codec supports.

--- a/cli/commands/genesis/storage.go
+++ b/cli/commands/genesis/storage.go
@@ -127,7 +127,7 @@ func SetDepositStorage(
 	}
 
 	depositAddr := common.Address(chainSpec.DepositContractAddress())
-	allocs := WriteDepositStorage(elGenesis, depositAddr, count, root)
+	allocs := writeDepositStorage(elGenesis, depositAddr, count, root)
 
 	// Get just the filename from the path
 	filename := filepath.Base(elGenesisFilePath)
@@ -142,6 +142,19 @@ func SetDepositStorage(
 }
 
 func WriteDepositStorage(
+	elGenesis types.EthGenesis,
+	depositAddr common.Address,
+	depositsCount *big.Int,
+	depositsRoot libcommon.Root,
+) gethprimitives.GenesisAlloc {
+
+	return writeDepositStorage(
+		elGenesis,
+		depositAddr,
+		depositsCount,
+		depositsRoot)
+}
+func writeDepositStorage(
 	elGenesis types.EthGenesis,
 	depositAddr common.Address,
 	depositsCount *big.Int,

--- a/cli/commands/genesis/storage.go
+++ b/cli/commands/genesis/storage.go
@@ -141,6 +141,7 @@ func SetDepositStorage(
 	return nil
 }
 
+// Exported function to write deposit storage to genesis alloc.
 func WriteDepositStorage(
 	elGenesis types.EthGenesis,
 	depositAddr common.Address,

--- a/cli/commands/genesis/storage.go
+++ b/cli/commands/genesis/storage.go
@@ -127,7 +127,7 @@ func SetDepositStorage(
 	}
 
 	depositAddr := common.Address(chainSpec.DepositContractAddress())
-	allocs := writeDepositStorage(elGenesis, depositAddr, count, root)
+	allocs := WriteDepositStorage(elGenesis, depositAddr, count, root)
 
 	// Get just the filename from the path
 	filename := filepath.Base(elGenesisFilePath)
@@ -141,7 +141,7 @@ func SetDepositStorage(
 	return nil
 }
 
-func writeDepositStorage(
+func WriteDepositStorage(
 	elGenesis types.EthGenesis,
 	depositAddr common.Address,
 	depositsCount *big.Int,

--- a/consensus-types/types/block_test.go
+++ b/consensus-types/types/block_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/berachain/beacon-kit/primitives/math"
 	"github.com/berachain/beacon-kit/primitives/version"
 	"github.com/berachain/beacon-kit/testing/utils"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/testing/runner/setup.go
+++ b/testing/runner/setup.go
@@ -52,7 +52,7 @@ const (
 )
 
 // pregeneratedEthAddresses returns an address defined in testing/files/eth-genesis.json
-func pregeneratedEthAddresses(i int) string {
+func pregeneratedEthAddresses(i uint64) string {
 	addresses := []string{
 		"0x0474f52d25529c4db5f4E72F43303dA71B3541C6",
 		"0x0e10cDAd84D788843aF48673C5b260A02ef78742",
@@ -159,7 +159,7 @@ func pregeneratedEthAddresses(i int) string {
 		"0xf6B6A52aA9BD788837c6682f47ACE009BD84b6fc",
 		"0xf97a36c417D33D1fC60a9163A8715e1aecb29102",
 	}
-	if i < 0 || i >= len(addresses) {
+	if i >= uint64(len(addresses)) {
 		panic(fmt.Sprintf("invalid eth address index %d", i))
 	}
 	return addresses[i]
@@ -312,7 +312,7 @@ func MakeGenesis(testnet *e2e.Testnet) (types.GenesisDoc, error) {
 		forkData := beaconkitconsensustypes.NewForkData(chainSpec.GenesisForkVersion(), common.Root{})
 		domainType := chainSpec.DomainTypeDeposit()
 
-		i := 0
+		var i uint64 = 0
 		for validator := range testnet.Validators {
 			executionAddress := common.NewExecutionAddressFromHex(pregeneratedEthAddresses(i))
 			credentials := beaconkitconsensustypes.NewCredentialsFromExecutionAddress(executionAddress)
@@ -334,6 +334,7 @@ func MakeGenesis(testnet *e2e.Testnet) (types.GenesisDoc, error) {
 				Amount:      amount,
 				Signature:   signature,
 				Credentials: credentials,
+				Index:       i,
 			}
 
 			appState.Deposits = append(appState.Deposits, deposit)

--- a/testing/runner/setup.go
+++ b/testing/runner/setup.go
@@ -506,7 +506,7 @@ func UpdateGenesis(genesis types.GenesisDoc, ethGenesisBz json.RawMessage) (type
 	if err != nil {
 		return types.GenesisDoc{}, err
 	}
-	eph, err := beaconkitgenesiscli.PublicExecutableDataToExecutionPayloadHeader(
+	eph, err := beaconkitgenesiscli.ExecutableDataToExecutionPayloadHeader(
 		chainSpec.GenesisForkVersion(),
 		payload,
 		chainSpec.MaxWithdrawalsPerPayload(),

--- a/testing/runner/setup.go
+++ b/testing/runner/setup.go
@@ -506,7 +506,7 @@ func UpdateGenesis(genesis types.GenesisDoc, ethGenesisBz json.RawMessage) (type
 	if err != nil {
 		return types.GenesisDoc{}, err
 	}
-	eph, err := beaconkitgenesiscli.ExecutableDataToExecutionPayloadHeader(
+	eph, err := beaconkitgenesiscli.PublicExecutableDataToExecutionPayloadHeader(
 		chainSpec.GenesisForkVersion(),
 		payload,
 		chainSpec.MaxWithdrawalsPerPayload(),

--- a/testing/runner/setup.go
+++ b/testing/runner/setup.go
@@ -10,14 +10,19 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"text/template"
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/berachain/beacon-kit/config/spec"
+	beaconkitconsensustypes "github.com/berachain/beacon-kit/consensus-types/types"
 	beaconkitconsensus "github.com/berachain/beacon-kit/consensus/cometbft/service"
+	"github.com/berachain/beacon-kit/node-core/components/signer"
+	"github.com/berachain/beacon-kit/primitives/common"
+	"github.com/berachain/beacon-kit/primitives/crypto"
+	"github.com/berachain/beacon-kit/primitives/math"
 	"github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cometbft/cometbft/libs/log"
@@ -42,7 +47,123 @@ const (
 	PrivvalDummyStateFile = "data/dummy_validator_state.json"
 
 	PrometheusConfigFile = "monitoring/prometheus.yml"
+
+	depositAmount = 32000000000
 )
+
+// pregeneratedEthAddresses returns an address defined in testing/files/eth-genesis.json
+func pregeneratedEthAddresses(i int) string {
+	addresses := []string{
+		"0x0474f52d25529c4db5f4E72F43303dA71B3541C6",
+		"0x0e10cDAd84D788843aF48673C5b260A02ef78742",
+		"0x0fb648Cb08e21602AF61AF53fE104E29d46433F7",
+		"0x10FdFa4EFc83d6CC42F5ef14c13da8b98E458214",
+		"0x12De044207a90709Ef2602D3D9D945d64dAe6147",
+		"0x14DA5251a1EB236238969575ccE943e2Fb0f4AA1",
+		"0x185F4Eebd01614aE3d12a5E49b184B054C46d37B",
+		"0x187bE38A1f448b0F42423151A683dCAea949008B",
+		"0x1CF7e940A657eE706718CF180eb21864DE9672C3",
+		"0x1a0A57e5e6a66aD732295ddAF0aed286a4e64310",
+		"0x1a0c826048DF0E4661E3c53bBd447d497E3f701F",
+		"0x1e2e53c2451d0f9ED4B7952991BE0c95165D5c01",
+		"0x1f1D0FCa7e19b799c315d4fDf31bA50e6A2AB153",
+		"0x20f33ce90a13a4b5e7697e3544c3083b8f8a51d4",
+		"0x25fc16D8E2314B305dF05C032E617638284801D6",
+		"0x28879749Dda99387bdB43295B28bdF251d999F3b",
+		"0x2B9935698dc5c19Ab7414AE22f27Da5F4478008a",
+		"0x2E5f031578e8FF82199aaF16f42c44D43Fe61819",
+		"0x2F4fD8a82A1400E654eeEC59b0e588445ffE0F96",
+		"0x2d88ECD4d8F4b0A954886eE8C0802aE14684cd07",
+		"0x2f6eB3D9a41157322dE01A6E707F6F118Cb00A7b",
+		"0x3124d9885b11B52c56A2aee610AfCf5740d484F0",
+		"0x3649839562C8dA64E6215EB0f5371629Ead9729D",
+		"0x3DFb4173ec41EB976260fd689E5AB9772C66beaf",
+		"0x3bd0E8f1B1E8Ec99a4E1762F4058F9884C93af31",
+		"0x3f51B3BB6A18141282Ba002F7709c7E2f337F961",
+		"0x4245537d9e3fb36fBBf054247FfFB28b0d931503",
+		"0x440C37b22e8D7469128Ea7De6ac2f31419B4A8b1",
+		"0x44a5FBfa7d6f3Fd92cca01f6764509f8Fc33dfa5",
+		"0x47575DAE85403cD408d4639068D1187C427B9897",
+		"0x49cE37B2019bb2d0B8b6a094ef87a6Dd625454A0",
+		"0x4Afe0DFDAcc91F0fA2AEe39F9eAd66b64d03EbD6",
+		"0x4bD04ABA9fc709835b1EE4789195d10E9e8E53F5",
+		"0x4dC3aC871b22F8a98197B0aae976a8dE08e5Bebe",
+		"0x4e59b44847b379578588920cA78FbF26c0B4956C",
+		"0x5145b1B855bca67A119CB02A42aF4Bdbc66B725C",
+		"0x51e15e71c865FE702C9347610667f83658A20e00",
+		"0x5227aaebCA3E5e893547A667666E2e4e12Ca20e0",
+		"0x54e1F990Dc0B7367F1E8eD96dA63BC4bca0E8061",
+		"0x56898d1aFb10cad584961eb96AcD476C6826e41E",
+		"0x5DD7bc3BEE395831ce499315ecAFE81DE0556F99",
+		"0x611a42A2EF62c2461D123e3F0B64b93938bc4781",
+		"0x62cB9bF32EA104f6D5eBf6879e876439f9492E4B",
+		"0x67c942Ef50Fc690eA779067a6A0d444a8234baB5",
+		"0x6CBcF4198fDA91D00fD469340E6DF6df086159e3",
+		"0x6F69542fC88fF84C480FFf510aB7108120447247",
+		"0x6a354C708fd248FD778F6adF75E41AA554700F68",
+		"0x719Be866A77CeEc1BaC4FD37910c0975eFd52f55",
+		"0x7469CeEf99FB67e4990c5F1c085a1B39b2902331",
+		"0x7689BE67b205EB5d32811d95D60587Eae4F3036F",
+		"0x795B761Db5969B7ba53472d5D37c230C859a472F",
+		"0x7c4d7dB81c544B768E1f4782011077202B74B5C0",
+		"0x7d7f187C2A05cDDCF700dCF2E02c96E7eF03f9B0",
+		"0x7f0E54bc3C1a72405646F5dFbBE0D4565c649fe2",
+		"0x800830F031ab1dd5895a5ec5B561427AD18f9ea8",
+		"0x868a33C94F91398B6245e1f0E4CF128B2F28714B",
+		"0x8724C57fb8f38A1FccA7177543dd1D8FcD49E5aa",
+		"0x8a88215ae882dfA519730c40109556c1C235729f",
+		"0x8b1e58f651CacaAa40291d2a6E0a6404d7Ed99e6",
+		"0x92B3feac5b7816Dcef96a303c1D5112271A70D2c",
+		"0x9C75eD1A37ae420b4FC0a1F4c26B673227Fd3AFa",
+		"0x9beFa0FB7a1A9E6cC7596204DbB8962E87091D64",
+		"0xA1d283f1a11A36D20FF38F29e12CA8F7Cf8709c1",
+		"0xA6177defF3b768b1D678EdF7583b8cf210C777c0",
+		"0xAC3c80F41C3049A89Aba8072FFbFc38a90fb6D8c",
+		"0xAf325Ccc92ae883DEF1634D499d8B093192D7a0c",
+		"0xB8865B4B8C56861534CC07ebBD2EA569a9a16323",
+		"0xBC3c03b4185A6F10618CC4E7B9f4AdD59AB5FbbA",
+		"0xBC9BC89b295a14F3976234Cc37C73e3D286f3a49",
+		"0xC4DD08191B4d5173e3698491A11e05b63F9Ee097",
+		"0xC4eD09A472B82516daa3A4d8D1E38AE94CF4855C",
+		"0xC59D8935c0570E75BA0E55E3C661f535C86e368B",
+		"0xD073a84e2ccDF91a9025179330438485E886D206",
+		"0xD2a3b89AE8D2c3bD39E2F24612ecFCD8600360C9",
+		"0xD3c5dAC705289cD005C402C79C8445a47502d8be",
+		"0xD6D4Fb22B91FAa54700852a05698B37d45514166",
+		"0xDE8E0E641E2Fb52c22460e6a1533c6BD13A00B37",
+		"0xDc6De65f6070b409125217a12Cf576A208Cc1998",
+		"0xDe5C7198e2416baB7e7a1EA758858Cd7301740bF",
+		"0xE3d2b9191EaBD3636A5dd057D522335cfae8c7CF",
+		"0xE5981AA0807eb05611cDb666e32e53b2001bd61d",
+		"0xE69ac59e1DF47291AaB8DEc540C796f81De7c892",
+		"0xE7F444b5f772281384117674002d540131e533Ca",
+		"0xF60fD8632Fc77E19b3A0637d115d0fdd06F36968",
+		"0xF99139D2FCc5E25F57B0B91fd382a21B3AFF9cbA",
+		"0xF9f58a87C3f0B3A4a0592938c80C41a7c659f855",
+		"0xFeb1eafa0154D291e28e393FAF10Bc89e5cCbB22",
+		"0xaEf63D7F7e2637c99FeA1B63366b244B4da12D70",
+		"0xb86d37333072eFb48cEaa46C67271A27CA5Bda82",
+		"0xb87fb371Bd3C2093b608cd0E7a8dDD60Bb05C995",
+		"0xbE651bc261b9Da5499a24Bf4214fD494c6e1F5Ac",
+		"0xbcC90AD39D377cA0b7b4F36eC463103E2728C33F",
+		"0xcB6632daA65e6c921c2963C37320f63f54fC8fE3",
+		"0xd0F043dED28773953562f824334C4cbb84210AE7",
+		"0xdBfb742BD2e0e6E353cb61E75B9e11257aC8fB1A",
+		"0xdb96E9cDD1e457b602f97d33e51736D7a5216496",
+		"0xdb9cB94B166DfdC9F337EA63b32B448d993d7008",
+		"0xe3024d098953661638d59E06f7FcD0B61c424854",
+		"0xea94749deFcc40dC5992687974b1C84B1bB9D6df",
+		"0xf11D16e2EE6BefED82Fbca0b005906E09303aB95",
+		"0xf22FbA9cBeB75ED353931418E9eca71EF1Ab9921",
+		"0xf4b2eb959A4C4b0E148340676999FC0446D446D4",
+		"0xf6B6A52aA9BD788837c6682f47ACE009BD84b6fc",
+		"0xf97a36c417D33D1fC60a9163A8715e1aecb29102",
+	}
+	if i < 0 || i >= len(addresses) {
+		panic(fmt.Sprintf("invalid eth address index %d", i))
+	}
+	return addresses[i]
+}
 
 // Setup sets up the testnet configuration.
 func Setup(testnet *e2e.Testnet, infp infra.Provider) error {
@@ -158,7 +279,7 @@ func MakeGenesis(testnet *e2e.Testnet) (types.GenesisDoc, error) {
 	genesis := types.GenesisDoc{
 		GenesisTime:     time.Now(),
 		ChainID:         testnet.Name,
-		ConsensusParams: types.DefaultConsensusParams(),
+		ConsensusParams: beaconkitconsensus.DefaultConsensusParams(crypto.CometBLSType),
 		InitialHeight:   testnet.InitialHeight,
 	}
 	// set the app version to 1
@@ -174,25 +295,60 @@ func MakeGenesis(testnet *e2e.Testnet) (types.GenesisDoc, error) {
 	if testnet.PbtsUpdateHeight == -1 {
 		genesis.ConsensusParams.Feature.PbtsEnableHeight = testnet.PbtsEnableHeight
 	}
-	for validator, power := range testnet.Validators {
-		genesis.Validators = append(genesis.Validators, types.GenesisValidator{
-			Name:    validator.Name,
-			Address: validator.PrivvalKey.PubKey().Address(),
-			PubKey:  validator.PrivvalKey.PubKey(),
-			Power:   power,
-		})
-	}
-	// The validator set will be sorted internally by CometBFT ranked by power,
-	// but we sort it here as well so that all genesis files are identical.
-	sort.Slice(genesis.Validators, func(i, j int) bool {
-		return strings.Compare(genesis.Validators[i].Name, genesis.Validators[j].Name) == -1
-	})
-	if len(testnet.InitialState) > 0 {
+	if len(testnet.InitialState) > 0 { //nolint:nestif
 		appState, err := json.Marshal(testnet.InitialState)
 		if err != nil {
 			return genesis, err
 		}
 		genesis.AppState = appState
+	} else {
+		chainSpec, err := spec.DevnetChainSpec()
+		if err != nil {
+			return genesis, err
+		}
+
+		appState := beaconkitconsensustypes.DefaultGenesis(chainSpec.GenesisForkVersion())
+		amount := math.Gwei(depositAmount)
+		forkData := beaconkitconsensustypes.NewForkData(chainSpec.GenesisForkVersion(), common.Root{})
+		domainType := chainSpec.DomainTypeDeposit()
+
+		i := 0
+		for validator := range testnet.Validators {
+			executionAddress := common.NewExecutionAddressFromHex(pregeneratedEthAddresses(i))
+			credentials := beaconkitconsensustypes.NewCredentialsFromExecutionAddress(executionAddress)
+			blsSigner := signer.BLSSigner{PrivValidator: types.MockPV{PrivKey: validator.PrivvalKey}}
+
+			var signature crypto.BLSSignature
+			_, signature, err = beaconkitconsensustypes.CreateAndSignDepositMessage(
+				forkData,
+				domainType,
+				blsSigner,
+				credentials,
+				amount)
+			if err != nil {
+				return genesis, err
+			}
+
+			deposit := &beaconkitconsensustypes.Deposit{
+				Pubkey:      blsSigner.PublicKey(), // compressed public key
+				Amount:      amount,
+				Signature:   signature,
+				Credentials: credentials,
+			}
+
+			appState.Deposits = append(appState.Deposits, deposit)
+			i++
+		}
+		gen := make(map[string]json.RawMessage)
+		gen["beacon"], err = json.Marshal(appState)
+		if err != nil {
+			return genesis, err
+		}
+		appStateJson, err := json.Marshal(gen)
+		if err != nil {
+			return genesis, err
+		}
+		genesis.AppState = appStateJson
 	}
 
 	// Customized genesis fields provided in the manifest


### PR DESCRIPTION
Closes https://github.com/informalsystems/security-partner-internal-pm/issues/79
[ext][Berachain] Change genesis generation in runner to generate beacond-compatible genesis

> Please rebase it on greg/e2e-framework, once #3 is merged.

* Rewrite how the app state is generated for the genesis file in `makeGenesis` in the runner.
