### PR TITLE
Added geth node to docker network

### DIFF
--- a/testing/runner/start.go
+++ b/testing/runner/start.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cometbft/cometbft/libs/log"
 	e2e "github.com/cometbft/cometbft/test/e2e/pkg"
 	"github.com/cometbft/cometbft/test/e2e/pkg/infra"
+	"github.com/cometbft/cometbft/test/e2e/pkg/infra/docker"
 )
 
 func Start(ctx context.Context, testnet *e2e.Testnet, p infra.Provider) error {
@@ -40,6 +41,12 @@ func Start(ctx context.Context, testnet *e2e.Testnet, p infra.Provider) error {
 		return errors.New("no initial nodes in testnet")
 	}
 
+	// Start geth node in docker - Todo: add geth node to manifest so it can also run in Digital Ocean
+	err := docker.ExecCompose(ctx, testnet.Dir, []string{"up", "-d", "geth"}...)
+	if err != nil {
+		return err
+	}
+
 	// Start initial nodes (StartAt: 0)
 	logger.Info("Starting initial network nodes...")
 	nodesAtZero := make([]*e2e.Node, 0)
@@ -47,7 +54,7 @@ func Start(ctx context.Context, testnet *e2e.Testnet, p infra.Provider) error {
 		nodesAtZero = append(nodesAtZero, nodeQueue[0])
 		nodeQueue = nodeQueue[1:]
 	}
-	err := p.StartNodes(context.Background(), nodesAtZero...)
+	err = p.StartNodes(context.Background(), nodesAtZero...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes https://github.com/informalsystems/security-partner-internal-pm/issues/122

This PR makes the runner create a pre-configured geth node for the validators.

This PR limits the execution of the runner to docker-based environments only. To lift this limit, we need to make changes in the underlying CometBFT e2e package.